### PR TITLE
WIP Feature/split aria and interactivity

### DIFF
--- a/accordion.test.ts
+++ b/accordion.test.ts
@@ -11,11 +11,12 @@ import {
     it('has a toggle button selector string', () => {
         const mockToggleButtonSelectorString: string = 'mock toggle button selector string';
         const mockContentWrapperSelectorString: string = 'mock content wrapper selector string';
-
         const accordionElementSelectorSetInstance: AccordionElementSelectorSet = new AccordionElementSelectorSet(
             mockToggleButtonSelectorString,
             mockContentWrapperSelectorString,
         );
+        expect(accordionElementSelectorSetInstance.toggleButtonSelector).toBeDefined();
+        expect(typeof accordionElementSelectorSetInstance.toggleButtonSelector).toEqual('string');
         expect(accordionElementSelectorSetInstance.toggleButtonSelector).toEqual(mockToggleButtonSelectorString);
     });
     it('has a content wrapper selector string', () => {
@@ -194,7 +195,7 @@ import {
     });
  });
 
- describe('The createAccordionKeyboardNavigationKeyUpHandler function', () => {
+describe('The createAccordionKeyboardNavigationKeyUpHandler function', () => {
 
     const mockToggleButtonId: string = 'mock-accordion-toggle-button';
     const mockContentWrappeId: string = 'mock-content-wrapper';

--- a/accordion/aria.test.ts
+++ b/accordion/aria.test.ts
@@ -1,0 +1,120 @@
+import { AccessibleElementSelectors } from "../base/types";
+import { makeAccessibleAccordion } from "./aria";
+import { AccordionElementSelectorSet } from "./types";
+
+describe('makeAccessibleAccordion function', () => {
+    const mockToggleButtonId: string = 'mock-accordion-toggle-button';
+    const mockContentWrappeId: string = 'mock-content-wrapper';
+    const mockAccordionHeadingText: string = 'mock-accordion-heading';
+    
+    const createAccordionElement = () => {
+        const accordionRootElement: HTMLElement = document.createElement('div');
+        const level3Heading: HTMLElement = document.createElement('h3');
+        const buttonElement: HTMLElement = document.createElement('button');
+        const contentWrapperElement: HTMLElement = document.createElement('div');
+
+        level3Heading.innerHTML = mockAccordionHeadingText;
+        buttonElement.setAttribute('id', mockToggleButtonId);
+        contentWrapperElement.setAttribute('id', mockContentWrappeId);
+        level3Heading.appendChild(buttonElement);
+        accordionRootElement.appendChild(level3Heading);
+        accordionRootElement.appendChild(contentWrapperElement);
+        return accordionRootElement;
+    };
+
+    it('applies role attribute to toggle button.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const toggleButton: Element | null = accordion.querySelector(selectorSet.toggleButtonSelector);
+        makeAccessibleAccordion(accordion, selectorSet);
+        expect(toggleButton?.getAttribute?.('role')).toEqual('button');
+    });
+    it('applies role attribute to toggle button with the default selector set.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const toggleButton: Element | null = accordion.querySelector(selectorSet.toggleButtonSelector);
+        makeAccessibleAccordion(accordion);
+        expect(toggleButton?.getAttribute?.('role')).toEqual('button');
+    });
+
+    it('applies aria-controls attribute equal to the content wrapper id to toggle button.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const toggleButton: Element | null = accordion.querySelector(selectorSet.toggleButtonSelector);
+        makeAccessibleAccordion(accordion, selectorSet);
+        expect(toggleButton?.getAttribute?.('aria-controls')).toEqual(mockContentWrappeId);
+    });
+
+    it('applies aria-controls attribute equal to the content wrapper id to toggle button with the default selector set.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const toggleButton: Element | null = accordion.querySelector(selectorSet.toggleButtonSelector);
+        makeAccessibleAccordion(accordion);
+        expect(toggleButton?.getAttribute?.('aria-controls')).toEqual(mockContentWrappeId);
+    });
+
+    it('applies aria-expanded attribute to toggle button.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const toggleButton: Element | null = accordion.querySelector(selectorSet.toggleButtonSelector);
+        makeAccessibleAccordion(accordion, selectorSet);
+        expect(toggleButton?.getAttribute?.('aria-expanded')).toEqual('false');
+    });
+
+    it('applies aria-expanded attribute to toggle button with a default selector set.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const toggleButton: Element | null = accordion.querySelector(selectorSet.toggleButtonSelector);
+        makeAccessibleAccordion(accordion);
+        expect(toggleButton?.getAttribute?.('aria-expanded')).toEqual('false');
+    });
+
+    it('applies role attribute to content wrapper.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const contentWrapper: Element | null = accordion.querySelector(selectorSet.contentWrapperSelector);
+        makeAccessibleAccordion(accordion, selectorSet);
+        expect(contentWrapper?.getAttribute?.('role')).toEqual('region');
+    });
+
+    it('applies role attribute to content wrapper with a default selector set.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const contentWrapper: Element | null = accordion.querySelector(selectorSet.contentWrapperSelector);
+        makeAccessibleAccordion(accordion);
+        expect(contentWrapper?.getAttribute?.('role')).toEqual('region');
+    });
+
+    it('applies aria-labelledby to content wrapper with toggle button id.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const contentWrapper: Element | null = accordion.querySelector(selectorSet.contentWrapperSelector);
+        makeAccessibleAccordion(accordion, selectorSet);
+        expect(contentWrapper?.getAttribute?.('aria-labelledby')).toEqual(mockToggleButtonId);
+    });
+
+    it('applies aria-labelledby to content wrapper with toggle button id with a default selector set.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const contentWrapper: Element | null = accordion.querySelector(selectorSet.contentWrapperSelector);
+        makeAccessibleAccordion(accordion);
+        expect(contentWrapper?.getAttribute?.('aria-labelledby')).toEqual(mockToggleButtonId);
+    });
+
+    it('applies hidden attribute to content wrapper.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const contentWrapper: Element | null = accordion.querySelector(selectorSet.contentWrapperSelector);
+        makeAccessibleAccordion(accordion, selectorSet);
+        expect(contentWrapper?.hasAttribute?.('hidden')).toBeTruthy();
+    });
+
+    it('applies hidden attribute to content wrapper with a default selector set.', () => {
+        const accordion: HTMLElement = createAccordionElement();
+        const selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        const contentWrapper: Element | null = accordion.querySelector(selectorSet.contentWrapperSelector);
+        makeAccessibleAccordion(accordion);
+        expect(contentWrapper?.hasAttribute?.('hidden')).toBeTruthy();
+    });    
+    
+});

--- a/accordion/aria.ts
+++ b/accordion/aria.ts
@@ -1,0 +1,45 @@
+import { AnyKindOfFunction } from "../utils";
+import {
+    ensureElementHasID,
+    targetElementIsToggleButton,
+    toggleExpandedHiddenState,
+} from "../utils/dom";
+import { AccordionElementSelectorSet } from "./types";
+
+
+/**
+ * Applies accessibility attributes, and behaviors in accordance with the W3C WAI specification for
+ * Accordian components. Refer to the W3C documentation https://www.w3.org/WAI/ARIA/apg/patterns/accordion/.
+ * 
+ * @param accordionElement DOM Element serving as the root element for selecting accordian elements.
+ * @param selectorSet DOM selector strings for identifying accordian elements.
+ * @returns Returns accordianElement.
+ * @see {AccessibleDecoratorUtils#toggleExpandedHiddenState}
+ */
+export function makeAccessibleAccordion(
+    accordionElement: HTMLElement,
+    selectorSet: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault(),
+): HTMLElement {
+
+    const toggleWrappers: NodeList = accordionElement.querySelectorAll(selectorSet.toggleButtonSelector);
+    const contentWrappers: NodeList = accordionElement.querySelectorAll(selectorSet.contentWrapperSelector);
+    const itemCount: number = Math.min(toggleWrappers.length, contentWrappers.length);
+    for (let i = 0; i < itemCount; ++i) {
+        const toggleElement: HTMLElement = toggleWrappers.item(i) as HTMLElement;
+        const contentWrapper: HTMLElement = contentWrappers.item(i) as HTMLElement;
+        const toggleId: string = ensureElementHasID(toggleElement);
+        const wrapperId: string = ensureElementHasID(contentWrapper);
+
+        toggleElement.setAttribute('role', 'button');
+        toggleElement.setAttribute('aria-controls', wrapperId);
+        toggleElement.setAttribute('aria-expanded', 'false');
+
+        contentWrapper.setAttribute('role', 'region');
+        contentWrapper.setAttribute('aria-labelledby', toggleId);
+        contentWrapper.setAttribute('hidden', '');
+
+        toggleExpandedHiddenState(toggleElement, contentWrapper);
+    }
+    
+    return accordionElement;
+}

--- a/accordion/interactivity.test.ts
+++ b/accordion/interactivity.test.ts
@@ -1,5 +1,5 @@
 import { targetElementIsToggleButton } from "../utils/dom";
-import { createAccordionKeyboardNavigationKeyUpHandler, InteractiveAccessibleAccordionElement } from "./interactivity";
+import { applyAccessibleAccordionInteractivity, createAccordionKeyboardNavigationKeyUpHandler, InteractiveAccessibleAccordionElement } from "./interactivity";
 import { AccessibleAccordionElementViewModel, AccordionElementSelectorSet } from "./types";
 
 const mockToggleButtonId: string = 'mock-accordion-toggle-button';
@@ -283,3 +283,17 @@ describe('The createAccordionKeyboardNavigationKeyUpHandler function', () => {
     });
  });
 
+describe('applyAccessibleAccordionInteractivity function', () => {
+    it('initializes keyboard interactivty.', () => {
+        const element: HTMLElement = createAccordionElement();
+        const viewModel: AccessibleAccordionElementViewModel = AccessibleAccordionElementViewModel.createDefault();
+        const interactivity: InteractiveAccessibleAccordionElement = applyAccessibleAccordionInteractivity(
+            element,
+            viewModel,
+        );
+        expect(interactivity.interactivityState).not.toBeNull();
+        expect(interactivity.isEventHandlerAttached).toEqual(true);
+        expect(interactivity.removeEventHandler()).toEqual(true);
+        expect(interactivity.cleanupHandlerState()).toEqual(true);
+    });
+});

--- a/accordion/interactivity.test.ts
+++ b/accordion/interactivity.test.ts
@@ -1,0 +1,285 @@
+import { targetElementIsToggleButton } from "../utils/dom";
+import { createAccordionKeyboardNavigationKeyUpHandler, InteractiveAccessibleAccordionElement } from "./interactivity";
+import { AccessibleAccordionElementViewModel, AccordionElementSelectorSet } from "./types";
+
+const mockToggleButtonId: string = 'mock-accordion-toggle-button';
+const mockContentWrappeId: string = 'mock-content-wrapper';
+const mockAccordionHeadingText: string = 'mock-accordion-heading';
+
+const createAccordionElement = () => {
+    const accordionRootElement: HTMLElement = document.createElement('div');
+    const level3Heading: HTMLElement = document.createElement('h3');
+    const buttonElement: HTMLElement = document.createElement('button');
+    const contentWrapperElement: HTMLElement = document.createElement('div');
+
+    level3Heading.innerHTML = mockAccordionHeadingText;
+    buttonElement.setAttribute('id', mockToggleButtonId);
+    contentWrapperElement.setAttribute('id', mockContentWrappeId);
+    level3Heading.appendChild(buttonElement);
+    accordionRootElement.appendChild(level3Heading);
+    accordionRootElement.appendChild(contentWrapperElement);
+    return accordionRootElement;
+};
+
+describe('InteractiveAccessibleAccordionElement', () => {
+    it('initializes an interactive state from an uninitialized state.', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        const element: HTMLElement = createAccordionElement();
+        const viewModel: AccessibleAccordionElementViewModel = AccessibleAccordionElementViewModel.createDefault();
+        expect(interactiveAccordion.initializeInteractiveState(element, viewModel)).toEqual(true);
+        expect(interactiveAccordion.interactivityState).not.toBeNull();
+        expect(interactiveAccordion.interactivityState?.element).toBe(element);
+        expect(interactiveAccordion.interactivityState?.viewModel).toBe(viewModel);
+        expect(interactiveAccordion.interactivityState?.handler).toBeInstanceOf(Function);
+        expect(typeof interactiveAccordion.interactivityState?.handler).toEqual('function');
+    });
+    it('does not initialize an interactive state from an attached initialized state.', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        const element: HTMLElement = createAccordionElement();
+        const viewModel: AccessibleAccordionElementViewModel = AccessibleAccordionElementViewModel.createDefault();
+        expect(interactiveAccordion.initializeInteractiveState(element, viewModel)).toEqual(true);
+        expect(interactiveAccordion.attachEventHandler()).toEqual(true);
+        expect(interactiveAccordion.initializeInteractiveState(element, viewModel)).toEqual(false);
+    });
+    it('attaches the event handler', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        const element: HTMLElement = createAccordionElement();
+        const viewModel: AccessibleAccordionElementViewModel = AccessibleAccordionElementViewModel.createDefault();
+        expect(interactiveAccordion.initializeInteractiveState(element, viewModel)).toEqual(true);
+        expect(interactiveAccordion.attachEventHandler()).toEqual(true);
+        expect(interactiveAccordion.isEventHandlerAttached).toEqual(true);
+    });
+    it('does not attach an event handler with an uninitialized state.', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        const element: HTMLElement = createAccordionElement();
+        const viewModel: AccessibleAccordionElementViewModel = AccessibleAccordionElementViewModel.createDefault();
+        expect(interactiveAccordion.attachEventHandler()).toEqual(false);
+        expect(interactiveAccordion.isEventHandlerAttached).toEqual(false);
+    });
+    it('removes the event handler.', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        const element: HTMLElement = createAccordionElement();
+        const viewModel: AccessibleAccordionElementViewModel = AccessibleAccordionElementViewModel.createDefault();
+        expect(interactiveAccordion.initializeInteractiveState(element, viewModel)).toEqual(true);
+        expect(interactiveAccordion.attachEventHandler()).toEqual(true);
+        expect(interactiveAccordion.isEventHandlerAttached).toEqual(true);
+        expect(interactiveAccordion.removeEventHandler()).toEqual(true);
+        expect(interactiveAccordion.isEventHandlerAttached).toEqual(false);
+    });
+    it('does not remove an event handler from an uninitialized state.', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        expect(interactiveAccordion.interactivityState).toBeNull();
+        expect(interactiveAccordion.removeEventHandler()).toEqual(false);
+    });
+    it('cleansup the interactivity state.', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        const element: HTMLElement = createAccordionElement();
+        const viewModel: AccessibleAccordionElementViewModel = AccessibleAccordionElementViewModel.createDefault();
+        expect(interactiveAccordion.initializeInteractiveState(element, viewModel)).toEqual(true);
+        expect(interactiveAccordion.cleanupHandlerState()).toEqual(true);
+    });
+    it('does not cleanup uninitialized interactivity state.', () => {
+        const interactiveAccordion: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+        expect(interactiveAccordion.cleanupHandlerState()).toEqual(false);
+    });
+});
+
+describe('The createAccordionKeyboardNavigationKeyUpHandler function', () => {
+
+    const mockToggleButtonId: string = 'mock-accordion-toggle-button';
+    const mockContentWrappeId: string = 'mock-content-wrapper';
+    const mockAccordionHeadingText: string = 'mock-accordion-heading';
+    const KEYUP: string = 'keyup';
+    const createAccordionElement: (accordionIndex?: number) => HTMLElement = (accordionIndex: number = 0): HTMLElement => {
+        const accordionRootElement: HTMLElement = document.createElement('div');
+        const level3Heading: HTMLElement = document.createElement('h3');
+        const buttonElement: HTMLElement = document.createElement('button');
+        const contentWrapperElement: HTMLElement = document.createElement('div');
+
+        level3Heading.innerHTML = mockAccordionHeadingText;
+        buttonElement.setAttribute('id', `${mockToggleButtonId}-${accordionIndex}`);
+        buttonElement.setAttribute('role', 'button');
+        buttonElement.setAttribute('aria-controls', `${mockContentWrappeId}-${accordionIndex}`);
+        buttonElement.setAttribute('aria-expanded', 'false');
+        buttonElement.textContent = 'Click me!';
+        contentWrapperElement.setAttribute('id', `${mockContentWrappeId}-${accordionIndex}`);
+        contentWrapperElement.textContent = 'Some text content';
+        level3Heading.appendChild(buttonElement);
+        accordionRootElement.appendChild(level3Heading);
+        accordionRootElement.appendChild(contentWrapperElement);
+        return accordionRootElement;
+    };
+
+    const createAccordionElementSet: (count: number) => HTMLElement = (count: number): HTMLElement => {
+        const wrapper: HTMLElement = document.createElement('div');
+        for (let i: number = 0; i < count; ++i) {
+            const accordion: HTMLElement = createAccordionElement(i);
+            wrapper.appendChild(accordion);
+        }
+        return wrapper;
+    };
+
+    const createSelectorSet: () => AccordionElementSelectorSet = () => {
+        return AccordionElementSelectorSet.createDefault();
+    };
+
+    it('returns a function that triggers a click event when Space and Enter keys are pressed on the target.', () => {
+        const clickHandler = jest.fn();
+        const accordion = createAccordionElement();
+        const buttonElement: HTMLElement | null = accordion.querySelector(`#${mockToggleButtonId}-0`);
+        if (buttonElement === null) {
+            throw new ReferenceError('buttonElement is null');
+        }
+        
+        buttonElement.addEventListener('click', clickHandler);
+        
+        expect(targetElementIsToggleButton(buttonElement)).toEqual(true);
+        const selectors: AccordionElementSelectorSet = createSelectorSet();
+        const keyUpHandler: (e: KeyboardEvent) => void = createAccordionKeyboardNavigationKeyUpHandler(
+            accordion,
+            selectors,
+        );
+        expect(keyUpHandler).toBeInstanceOf(Function);
+        accordion.addEventListener(KEYUP, keyUpHandler as EventListenerOrEventListenerObject);
+        const spaceKeyUp: KeyboardEvent = new KeyboardEvent(KEYUP, {
+            code: 'Space',
+            key: ' ',
+            bubbles: true,
+        });
+        const enterKeyUp: KeyboardEvent = new KeyboardEvent(KEYUP, {
+            code: 'Enter',
+            key: 'Enter',
+            bubbles: true,
+        });
+        
+        const toggles: Node[] = Array.from(accordion.querySelectorAll(selectors.toggleButtonSelector));
+        expect(toggles.length).toEqual(1);
+
+        buttonElement.dispatchEvent(spaceKeyUp);
+        expect(clickHandler).toHaveBeenCalledTimes(1);
+        buttonElement.dispatchEvent(enterKeyUp);
+        expect(clickHandler).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns a function that triggers focus on the next and previous accordion toggle buttons via arrow up and down.', () => {
+        const accordionCount: number = 3;
+        const accordionSet: HTMLElement = createAccordionElementSet(accordionCount);
+        const selectors: AccordionElementSelectorSet = new AccordionElementSelectorSet(
+            ':scope > div > h3 > button',
+            ':scope > div > div',
+        );
+        const keyUpHandler: (e: KeyboardEvent) => void = createAccordionKeyboardNavigationKeyUpHandler(
+            accordionSet,
+            selectors,
+        );
+        const toggleButtons: NodeList = accordionSet.querySelectorAll(selectors.toggleButtonSelector);
+        const focusHandlers: jest.Mock[]= [];
+        const focusCallCounts: number[] = [];
+        expect(toggleButtons.length).toEqual(accordionCount);
+
+        toggleButtons.forEach((toggleButtonNode: Node) => {
+            const toggleButtonElement: HTMLElement = toggleButtonNode as HTMLElement;
+            const focusHandler: jest.Mock = jest.fn();
+            focusHandlers.push(focusHandler);
+            focusCallCounts.push(0);
+            toggleButtonElement.addEventListener('focus', focusHandler);
+        });
+        const arrowDownModel: [number, number][] = [[0, 1], [1, 2], [2, 0]];
+        const arrowUpModel: [number, number][] = [[0, 2], [2, 1], [1, 0]];
+        
+        const EXPECTED_FOCUS_CALL_COUNT: number = arrowDownModel.length + arrowUpModel.length + 2;
+
+        accordionSet.addEventListener(KEYUP, keyUpHandler as EventListenerOrEventListenerObject);
+        arrowDownModel.forEach(([current, next]) => {
+            const toggleButtonElement: HTMLElement = toggleButtons.item(current) as HTMLElement;
+            if (current === 0) {
+                toggleButtonElement.focus();
+                focusCallCounts[current] = focusCallCounts[current] + 1;
+            }
+            const arrowKeyEvent: KeyboardEvent = new KeyboardEvent(KEYUP, {
+                code: 'ArrowDown',
+                key: 'ArrowDown',
+                bubbles: true,
+            });
+            toggleButtonElement.dispatchEvent(arrowKeyEvent);
+            focusCallCounts[next] = focusCallCounts[next] + 1;
+        });
+        arrowUpModel.forEach(([current, next]) => {
+            const toggleButtonElement: HTMLElement = toggleButtons.item(current) as HTMLElement;
+            if (current === 0) {
+                toggleButtonElement.focus();
+                focusCallCounts[current] = focusCallCounts[current] + 1;
+            }
+            const arrowKeyEvent: KeyboardEvent = new KeyboardEvent(KEYUP, {
+                code: 'ArrowUp',
+                key: 'ArrowUp',
+                bubbles: true,
+            });
+            toggleButtonElement.dispatchEvent(arrowKeyEvent);
+            focusCallCounts[next] = focusCallCounts[next] + 1;
+        });
+        const focusHandlerCallSum: number = focusCallCounts.reduce((carry, current) => carry + current, 0);
+        expect(EXPECTED_FOCUS_CALL_COUNT).toEqual(focusHandlerCallSum);
+    });
+    it('returns a function that focuses the first accordion toggle when the Home button is pressed.', () => {
+        const accordionCount: number = 3;
+        const accordionSet: HTMLElement = createAccordionElementSet(accordionCount);
+        const selectors: AccordionElementSelectorSet = new AccordionElementSelectorSet(
+            ':scope > div > h3 > button',
+            ':scope > div > div',
+        );
+        const keyUpHandler: (e: KeyboardEvent) => void = createAccordionKeyboardNavigationKeyUpHandler(
+            accordionSet,
+            selectors,
+        );
+        accordionSet.addEventListener(KEYUP, keyUpHandler as EventListenerOrEventListenerObject);
+
+        const toggleButtons: NodeList = accordionSet.querySelectorAll(selectors.toggleButtonSelector);
+        expect(toggleButtons.length).toEqual(accordionCount);
+
+        const firstToggleButton: HTMLElement = toggleButtons.item(0) as HTMLElement;
+        const lastToggleButton: HTMLElement = toggleButtons.item(toggleButtons.length - 1) as HTMLElement;
+        const firstToggleFocusHandler: jest.Mock = jest.fn();
+
+        firstToggleButton.addEventListener('focus', firstToggleFocusHandler);
+        lastToggleButton.focus();
+        
+        const homeKeyEvent: KeyboardEvent = new KeyboardEvent(KEYUP, {
+            code: 'Home',
+            key: 'Home',
+            bubbles: true,
+        });
+        lastToggleButton.dispatchEvent(homeKeyEvent);
+        expect(firstToggleFocusHandler).toHaveBeenCalled();
+    });
+    it('returns a function that focuses the last accordion toggle when the End button is pressed.', () => {
+        const accordionCount: number = 3;
+        const accordionSet: HTMLElement = createAccordionElementSet(accordionCount);
+        const selectors: AccordionElementSelectorSet = new AccordionElementSelectorSet(
+            ':scope > div > h3 > button',
+            ':scope > div > div',
+        );
+        const keyUpHandler: (e: KeyboardEvent) => void = createAccordionKeyboardNavigationKeyUpHandler(
+            accordionSet,
+            selectors,
+        );
+        const toggleButtons: NodeList = accordionSet.querySelectorAll(selectors.toggleButtonSelector);
+        accordionSet.addEventListener(KEYUP, keyUpHandler as EventListenerOrEventListenerObject);
+        
+        expect(toggleButtons.length).toEqual(accordionCount);
+        const firstToggleButton: HTMLElement = toggleButtons[0] as HTMLElement;
+        const lastToggleButton: HTMLElement = toggleButtons[toggleButtons.length - 1] as HTMLElement;
+        const lastToggleFocusHandler: jest.Mock = jest.fn();
+
+        firstToggleButton.focus();
+        lastToggleButton.addEventListener('focus', lastToggleFocusHandler);
+        const endKeyEvent: KeyboardEvent = new KeyboardEvent(KEYUP, {
+            code: 'End',
+            key: 'End',
+            bubbles: true,
+        });
+        firstToggleButton.dispatchEvent(endKeyEvent);
+        expect(lastToggleFocusHandler).toHaveBeenCalled();
+    });
+ });
+

--- a/accordion/interactivity.ts
+++ b/accordion/interactivity.ts
@@ -1,0 +1,108 @@
+import { ActionInvocationOption, createClickActionInvoker, createElementAction, createFocusActionInvoker, createKeyboardEventResponder, DOMActionInvoker, ElementActionAntecedent, KeyboardEventResponder, KeyboardEventResponderInit, KeyboardEventResponse } from "../base/events";
+import { AccessibleElementViewModel, InteractiveAccessibleElement, KeyEventCallback } from "../base/types";
+import { AnyKindOfFunction } from "../base/types";
+import { nextWrapAroundIndex, WrapAroundDirection } from "../utils/collections";
+import { targetElementIsToggleButton } from "../utils/dom";
+import { AccessibleAccordionElementViewModel, AccordionElementSelectorSet } from "./types";
+
+export function createAccordionKeyboardNavigationKeyUpHandler(
+    accordionElement: HTMLElement,
+    selectors: AccordionElementSelectorSet,
+): (e: KeyboardEvent) => void {
+    return (e: KeyboardEvent) => {
+        const { target, key } = e;
+        if (targetElementIsToggleButton(target)) {
+            const toggles: Node[] = Array.from(accordionElement.querySelectorAll(selectors.toggleButtonSelector));
+            if (key === ' ' || key === 'Enter') {
+                (target as HTMLElement).click();
+            } else if (key === 'ArrowUp' || key === 'ArrowDown') {
+                const direction: number = ({ 'ArrowUp': -1, 'ArrowDown': 1 })[key];
+                const targetIndex: number | undefined = toggles.findIndex(node => node === target);
+                if (typeof targetIndex !== 'undefined') {
+                    let nextIndex: number = targetIndex + direction;
+                    if (nextIndex === toggles.length) {
+                        nextIndex = 0
+                    } else if (nextIndex === -1) {
+                        nextIndex = toggles.length - 1;
+                    }
+                    const nextElement: HTMLElement = toggles[nextIndex] as HTMLElement;
+                    nextElement.focus();
+                }
+            } else if (key === 'Home') {
+                (toggles[0] as HTMLElement).focus();
+                (toggles[0] as EventTarget).dispatchEvent(new FocusEvent('focus', {
+                    bubbles: true,
+                }));
+            } else if (key === 'End') {
+                (toggles[toggles.length - 1] as HTMLElement).focus();
+                (toggles[toggles.length - 1] as EventTarget).dispatchEvent(new FocusEvent('focus', {
+                    bubbles: true,
+                }));
+            }
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    };
+}
+
+export class InteractiveAccessibleAccordionElement extends InteractiveAccessibleElement<
+    AccordionElementSelectorSet,
+    AccessibleAccordionElementViewModel,
+    KeyboardEvent
+> {
+    public constructor(
+        public isEventHandlerAttached: boolean = false,
+    ) {
+        super();
+    }
+
+    public initializeInteractiveState(element: HTMLElement, viewModel: AccessibleAccordionElementViewModel): boolean {
+        if (this.isEventHandlerAttached) {
+            return false;
+        }
+        this.patternState = {
+            element: element,
+            viewModel: viewModel,
+            handler: createAccordionKeyboardNavigationKeyUpHandler(element, viewModel.selectors),
+        };
+        return true;
+    }
+
+    public attachEventHandler(): boolean {
+        if (this.patternState) {
+            const { element, handler } = this.patternState;
+            element.addEventListener('keyup', handler);
+            return this.isEventHandlerAttached = true;
+        } else {
+            return false;
+        }
+    }
+
+    public removeEventHandler(): boolean {
+        if (this.patternState && this.isEventHandlerAttached) {
+            const { element, handler } = this.patternState;
+            element.removeEventListener('keyup', handler);
+            this.isEventHandlerAttached = false;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public cleanupHandlerState(): boolean {
+        if (this.patternState) {
+            this.removeEventHandler();
+            this.patternState = null;
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+
+// function applyAccessibleAccordionInteractivity(
+//     accordionElement: HTMLElement,
+//     messageBus: 
+// ): ElementInteractivityObserver {
+
+// }

--- a/accordion/interactivity.ts
+++ b/accordion/interactivity.ts
@@ -1,7 +1,5 @@
-import { ActionInvocationOption, createClickActionInvoker, createElementAction, createFocusActionInvoker, createKeyboardEventResponder, DOMActionInvoker, ElementActionAntecedent, KeyboardEventResponder, KeyboardEventResponderInit, KeyboardEventResponse } from "../base/events";
-import { AccessibleElementViewModel, InteractiveAccessibleElement, KeyEventCallback } from "../base/types";
-import { AnyKindOfFunction } from "../base/types";
-import { nextWrapAroundIndex, WrapAroundDirection } from "../utils/collections";
+
+import { InteractiveAccessibleElement } from "../base/types";
 import { targetElementIsToggleButton } from "../utils/dom";
 import { AccessibleAccordionElementViewModel, AccordionElementSelectorSet } from "./types";
 

--- a/accordion/interactivity.ts
+++ b/accordion/interactivity.ts
@@ -98,9 +98,12 @@ export class InteractiveAccessibleAccordionElement extends InteractiveAccessible
     }
 }
 
-// function applyAccessibleAccordionInteractivity(
-//     accordionElement: HTMLElement,
-//     messageBus: 
-// ): ElementInteractivityObserver {
-
-// }
+export function applyAccessibleAccordionInteractivity(
+    accordionElement: HTMLElement,
+    viewModel: AccessibleAccordionElementViewModel,
+): InteractiveAccessibleAccordionElement {
+    const interactivity: InteractiveAccessibleAccordionElement = new InteractiveAccessibleAccordionElement();
+    interactivity.initializeInteractiveState(accordionElement, viewModel);
+    interactivity.attachEventHandler();
+    return interactivity;
+}

--- a/accordion/types.test.ts
+++ b/accordion/types.test.ts
@@ -1,0 +1,43 @@
+import { AccordionElementSelectorSet } from "./types";
+
+ describe('Accordion element selector set class', () => {
+    it('has a toggle button selector string', () => {
+        const mockToggleButtonSelectorString: string = 'mock toggle button selector string';
+        const mockContentWrapperSelectorString: string = 'mock content wrapper selector string';
+        const accordionElementSelectorSetInstance: AccordionElementSelectorSet = new AccordionElementSelectorSet(
+            mockToggleButtonSelectorString,
+            mockContentWrapperSelectorString,
+        );
+        expect(accordionElementSelectorSetInstance.toggleButtonSelector).toBeDefined();
+        expect(typeof accordionElementSelectorSetInstance.toggleButtonSelector).toEqual('string');
+        expect(accordionElementSelectorSetInstance.toggleButtonSelector).toEqual(mockToggleButtonSelectorString);
+    });
+    it('has a content wrapper selector string', () => {
+        const mockToggleButtonSelectorString: string = 'mock toggle button selector string';
+        const mockContentWrapperSelectorString: string = 'mock content wrapper selector string';
+
+        const accordionElementSelectorSetInstance: AccordionElementSelectorSet = new AccordionElementSelectorSet(
+            mockToggleButtonSelectorString,
+            mockContentWrapperSelectorString,
+        );
+        expect(accordionElementSelectorSetInstance.contentWrapperSelector).toEqual(mockContentWrapperSelectorString);
+    });
+    it('has a default toggle button selector', () => {
+        const toggleButtonSelector: string = ':scope > h3 > button';
+        expect(AccordionElementSelectorSet.DEFAULT_TOGGLE_BUTTON_SELECTOR).toEqual(toggleButtonSelector);
+    });
+    it('has a default content wrapper selector string.', () => {
+        const contentWrapperSelector: string = ':scope > div';
+        expect(AccordionElementSelectorSet.DEFAULT_CONTENT_WRAPPER_SELECTOR).toEqual(contentWrapperSelector);
+    });
+    it('creates an instance with default values.', () => {
+        const defaultInstance: AccordionElementSelectorSet = AccordionElementSelectorSet.createDefault();
+        expect(defaultInstance.toggleButtonSelector).toEqual(AccordionElementSelectorSet.DEFAULT_TOGGLE_BUTTON_SELECTOR);
+        expect(defaultInstance.contentWrapperSelector).toEqual(AccordionElementSelectorSet.DEFAULT_CONTENT_WRAPPER_SELECTOR);
+    });
+    it('has a constructor with default value initialization.', () => {
+        const instance: AccordionElementSelectorSet = new AccordionElementSelectorSet();
+        expect(instance.queryRoot).toEqual(AccordionElementSelectorSet.DEFAULT_QUERY_ROOT_SELECTOR);
+        expect(instance.toggleButtonSelector).toEqual(AccordionElementSelectorSet.DEFAULT_TOGGLE_BUTTON_SELECTOR);
+    });
+});

--- a/accordion/types.ts
+++ b/accordion/types.ts
@@ -1,0 +1,49 @@
+import { AccessibleElementLabelViewModel, AccessibleElementSelectors, AccessibleElementViewModel } from "../base/types";
+
+export class AccordionElementSelectorSet extends AccessibleElementSelectors {
+
+    public static readonly DEFAULT_TOGGLE_BUTTON_SELECTOR = ':scope > h3 > button';
+    public static readonly DEFAULT_CONTENT_WRAPPER_SELECTOR = ':scope > div';
+
+    constructor(
+        public readonly toggleButtonSelector: string = AccordionElementSelectorSet.DEFAULT_TOGGLE_BUTTON_SELECTOR,
+        public readonly contentWrapperSelector: string = AccordionElementSelectorSet.DEFAULT_CONTENT_WRAPPER_SELECTOR,
+        protected readonly queryRootSelector: string = AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR,
+        protected readonly accessibleElementSelector: string = AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR,
+    ) {
+        super(queryRootSelector, accessibleElementSelector);
+    }
+
+    /**
+     * Returns an instance of AccordionElementSelectorSet with the default values
+     * for toggle button and content wrapper selectors defined in the corresponding
+     * static class properties.
+     * 
+     * @returns 
+     */
+    public static createDefault(): AccordionElementSelectorSet {
+        return new AccordionElementSelectorSet(
+            AccordionElementSelectorSet.DEFAULT_TOGGLE_BUTTON_SELECTOR,
+            AccordionElementSelectorSet.DEFAULT_CONTENT_WRAPPER_SELECTOR,
+            AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR,
+            AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR,
+        );
+    }
+}
+
+
+export class AccessibleAccordionElementViewModel extends AccessibleElementViewModel<AccordionElementSelectorSet> {
+    public constructor(
+        public readonly selectors: AccordionElementSelectorSet,
+        public readonly labelViewModel: AccessibleElementLabelViewModel,
+    ) {
+        super(selectors, labelViewModel);
+    }
+
+    public static createDefault(): AccessibleAccordionElementViewModel {
+        return new AccessibleAccordionElementViewModel(
+            AccordionElementSelectorSet.createDefault(),
+            AccessibleElementLabelViewModel.createDefault(),
+        );
+    }
+}

--- a/alert-dialog.ts
+++ b/alert-dialog.ts
@@ -1,3 +1,4 @@
+import { AccessibleElementDescriptionViewModel } from './base/types';
 import { AccessibleElementLabelViewModel, AccessibleElementViewModel, applyDescribedBy } from './utils';
 
 export class AlertDialogElementSelectorSet {

--- a/alert-dialog/aria.test.ts
+++ b/alert-dialog/aria.test.ts
@@ -1,0 +1,157 @@
+import {
+    AccessibleElementDescriptionViewModel,
+    AccessibleElementLabelSelectorPreference,
+    AccessibleElementLabelViewModel,
+    AccessibleElementSelectors,
+} from "../base/types";
+import { makeAccessibleAlertDialog } from "./aria";
+import { AccessibleAlertDialogViewModel } from "./types";
+
+describe('makeAccessibleAlertDialog function', () => {
+    const mockSelectors: AccessibleElementSelectors = new AccessibleElementSelectors('', '');
+    const mockDescriptionViewModel: AccessibleElementDescriptionViewModel = new AccessibleElementDescriptionViewModel(
+        '#description-id',
+        '',
+    );
+    const mockLabelId: string = 'label-id';
+    const mockLabelText: string = 'label text';
+    const mockLabelElementSelector: string = ':scope > div:nth-of-type(1)';
+    const mockDescriptionId: string = 'description-id';
+
+    const createElement: () => Element = () => {
+        const rootElement: Element = document.createElement('div');
+        const labelElement: Element = document.createElement('div');
+        const descriptionElement: Element = document.createElement('div');
+        labelElement.setAttribute('id', mockLabelId);
+        descriptionElement.setAttribute('id', mockDescriptionId);
+        rootElement.append(labelElement, descriptionElement);
+        return rootElement;
+    };
+
+    it('applies an aria-label attribute when defined via the view model.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            AccessibleElementLabelSelectorPreference.LABEL_TEXT,
+        );
+        const isModal: boolean = true;
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            isModal,
+            mockSelectors,
+            mockLabelViewModel,
+            mockDescriptionViewModel,
+        );
+        const alertDialogElement: Element = makeAccessibleAlertDialog(
+            createElement(),
+            mockDialogViewModel,
+        );
+        expect(alertDialogElement.getAttribute('aria-label')).toEqual(mockLabelViewModel.labelText);
+
+    });
+    it('applies an aria-labelledby attribute when defined via the view model.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            AccessibleElementLabelSelectorPreference.LABEL_ID,
+        );
+        const isModal: boolean = true;
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            isModal,
+            mockSelectors,
+            mockLabelViewModel,
+            mockDescriptionViewModel,
+        );
+        const alertDialogElement: Element = makeAccessibleAlertDialog(
+            createElement(),
+            mockDialogViewModel,
+        );
+        expect(alertDialogElement.getAttribute('aria-labelledby')).toEqual(mockLabelViewModel.labelId);
+    });
+    it('applies an aria-labelledby attribute via a selectable element when defined via the view model.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            AccessibleElementLabelSelectorPreference.LABEL_ELEMENT_SELECTOR,
+        );
+        const isModal: boolean = true;
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            isModal,
+            mockSelectors,
+            mockLabelViewModel,
+            mockDescriptionViewModel,
+        );
+        const alertDialogElement: Element = makeAccessibleAlertDialog(
+            createElement(),
+            mockDialogViewModel,
+        );
+        expect(alertDialogElement.getAttribute('aria-labelledby')).toEqual(mockLabelViewModel.labelId);
+    });
+    it('applies an aria-describedby attribute via a selectable element when defined via the view model.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            AccessibleElementLabelSelectorPreference.LABEL_ID,
+        );
+        const isModal: boolean = true;
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            isModal,
+            mockSelectors,
+            mockLabelViewModel,
+            mockDescriptionViewModel,
+        );
+        const alertDialogElement: Element = makeAccessibleAlertDialog(
+            createElement(),
+            mockDialogViewModel,
+        );
+        expect(alertDialogElement.getAttribute('aria-describedby')).toEqual(mockDescriptionId);
+    });
+    it('applies the role attribute.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            AccessibleElementLabelSelectorPreference.LABEL_ID,
+        );
+        const isModal: boolean = true;
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            isModal,
+            mockSelectors,
+            mockLabelViewModel,
+            mockDescriptionViewModel,
+        );
+        const alertDialogElement: Element = makeAccessibleAlertDialog(
+            createElement(),
+            mockDialogViewModel,
+        );
+        expect(alertDialogElement.getAttribute('role')).toEqual(AccessibleAlertDialogViewModel.DIALOG_ROLE_NAME);
+    });
+    it('applies the aria-modal attribute.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            AccessibleElementLabelSelectorPreference.LABEL_ID,
+        );
+        const isModal: boolean = true;
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            isModal,
+            mockSelectors,
+            mockLabelViewModel,
+            mockDescriptionViewModel,
+        );
+        const alertDialogElement: Element = makeAccessibleAlertDialog(
+            createElement(),
+            mockDialogViewModel,
+        );
+        expect(alertDialogElement.getAttribute('aria-modal')).toEqual('true');
+    });
+    it('uses a default view model.', () => {
+        const alertElement: Element = createElement();
+        const madeAccessibleAlert: Element = makeAccessibleAlertDialog(alertElement);
+        expect(madeAccessibleAlert.getAttribute('role')).toEqual(AccessibleAlertDialogViewModel.DIALOG_ROLE_NAME);
+    });
+});

--- a/alert-dialog/aria.ts
+++ b/alert-dialog/aria.ts
@@ -1,0 +1,28 @@
+import { AccessibleElementDescriptionViewModel, AccessibleElementLabelViewModel } from "../base/types";
+import { selectElementOrDefault } from "../utils/dom";
+import { AccessibleAlertDialogViewModel } from "./types";
+
+/**
+ * Applies accessibility attributes that satisfy the requirements defined by the W3C WAI
+ * Alert Dialog Box Pattern. Refer to the W3C documentation: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/examples/alertdialog/.
+ * 
+ * @param dialogElement DOM element serves as the root node for the dialog box elements.
+ * @param selectors DOM selector strings for querying the root element for dialog box elements.
+ * @returns Returns dialogElement.
+ * @throws {ReferenceError} A ReferenceError is thrown if the provided selectors do not identify existing elements.
+ * @see {https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/examples/alertdialog/}
+ */
+export function makeAccessibleAlertDialog(
+    dialogElement: Element,
+    viewModel: AccessibleAlertDialogViewModel = AccessibleAlertDialogViewModel.createDefault(),
+): Element {
+    const { selectors, labelViewModel, isModal, descriptionViewModel } = viewModel;
+    const rootElement: Element = selectElementOrDefault(dialogElement, selectors.queryRoot);
+    const componentElement: Element = selectElementOrDefault(rootElement, selectors.accessibleElement);
+    
+    AccessibleElementLabelViewModel.applyAccessibleLabel(componentElement, labelViewModel);
+    AccessibleElementDescriptionViewModel.applyDescribedBy(componentElement, descriptionViewModel);
+    componentElement.setAttribute('role', AccessibleAlertDialogViewModel.DIALOG_ROLE_NAME);
+    componentElement.setAttribute('aria-modal', `${isModal}`);
+    return dialogElement;
+}

--- a/alert-dialog/types.test.ts
+++ b/alert-dialog/types.test.ts
@@ -1,0 +1,71 @@
+import { AccessibleElementLabelSelectorPreference, AccessibleElementLabelViewModel, AccessibleElementSelectors } from "../base/types";
+import { AccessibleAlertDialogViewModel } from "./types";
+
+describe('AccessibleAlertDialogViewModel class', () => {
+    const mockSelectors: AccessibleElementSelectors = AccessibleElementSelectors.createDefault();
+    const mockLabelId: string = 'label-id';
+    const mockLabelText: string = 'label text';
+    const mockLabelElementSelector: string = ':scope > label';
+    const mockPreference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_ID;
+    
+    it('defines a role name static class property.', () => {
+        expect(AccessibleAlertDialogViewModel.DIALOG_ROLE_NAME).toBeTruthy();
+        expect(AccessibleAlertDialogViewModel.DIALOG_ROLE_NAME).not.toEqual('');
+        expect(typeof AccessibleAlertDialogViewModel.DIALOG_ROLE_NAME).toEqual('string');
+    });
+    it('initializes a selector set property upon construction.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            mockPreference,
+        );
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            true,
+            mockSelectors,
+            mockLabelViewModel,
+        );
+        expect(mockDialogViewModel.selectors).toBeDefined();
+        expect(mockDialogViewModel.selectors instanceof AccessibleElementSelectors).toEqual(true);
+
+    });
+    it('initializes a label view model property upon construction.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            mockPreference,
+        );
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            true,
+            mockSelectors,
+            mockLabelViewModel,
+        );
+        expect(mockDialogViewModel.labelViewModel).toBeDefined();
+        expect(mockDialogViewModel.labelViewModel instanceof AccessibleElementLabelViewModel).toEqual(true);
+    });
+    it('initializes a boolean property indicating modal state upon construction.', () => {
+        const mockLabelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            mockLabelId,
+            mockLabelText,
+            mockLabelElementSelector,
+            mockPreference,
+        );
+        const isModal: boolean = true;
+        const mockDialogViewModel: AccessibleAlertDialogViewModel = new AccessibleAlertDialogViewModel(
+            isModal,
+            mockSelectors,
+            mockLabelViewModel,
+        );
+        expect(mockDialogViewModel.isModal).toEqual(isModal);
+    });
+    it('initiates an instance with default values with its static createDefault factory function.', () => {
+        const instance: AccessibleAlertDialogViewModel = AccessibleAlertDialogViewModel.createDefault();
+        expect(instance.selectors).toBeDefined();
+        expect(instance.selectors).toBeInstanceOf(AccessibleElementSelectors);
+        expect(instance.isModal).toBeDefined();
+        expect(typeof instance.isModal).toEqual('boolean');
+        expect(instance.labelViewModel).toBeDefined();
+        expect(instance.labelViewModel).toBeInstanceOf(AccessibleElementLabelViewModel);
+    });
+});

--- a/alert-dialog/types.ts
+++ b/alert-dialog/types.ts
@@ -1,0 +1,64 @@
+import {
+    AccessibleElementDescriptionViewModel,
+    AccessibleElementLabelViewModel,
+    AccessibleElementSelectors,
+    AccessibleElementViewModel,
+} from "../base/types";
+
+/**
+ * View model for accessible alert dialog components.
+ * @see {https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/}
+ */
+export class AccessibleAlertDialogViewModel extends AccessibleElementViewModel<AccessibleElementSelectors> {
+
+    /**
+     * The value for the ARIA role of an alert dialog.
+     * @value "alertdialog"
+     */
+    public static readonly DIALOG_ROLE_NAME = 'alertdialog';
+
+    /**
+     * @param isModal 
+     * @param selectors 
+     * @param labelViewModel 
+     * @param descriptionViewModel 
+     * @see {AccessibleElementViewModel#constructor}
+     */
+    public constructor(
+
+
+        /**
+         * Whether or not the dialog is a modal dialog.
+         * @default true
+         */
+        public readonly isModal: boolean = true,
+
+        /**
+         * @see {AccessibleElementViewModel#constructor}
+         * @see {AccessibleElementViewModel#selectors}
+         */
+        public readonly selectors: AccessibleElementSelectors = AccessibleElementSelectors.createDefault(),
+
+        /**
+         * @see {AccessibleElementViewModel#constructor}
+         * @see {AccessibleElememntViewModel#labelViewModel}
+         */
+        public labelViewModel: AccessibleElementLabelViewModel = AccessibleElementLabelViewModel.createDefault(),
+
+        /**
+         * @see {AccessibleElementViewModel#constructor}
+         * @see {AccessibleElementViewModel#descriptionViewModel}
+         */
+        public descriptionViewModel: AccessibleElementDescriptionViewModel = AccessibleElementDescriptionViewModel.createDefault(),
+    ) {
+       super(selectors, labelViewModel, descriptionViewModel); 
+    }
+
+    /**
+     * Return a new instance with default property values.
+     * @returns Instance reference with default property values.
+     */
+    public static createDefault(): AccessibleAlertDialogViewModel {
+        return new AccessibleAlertDialogViewModel();
+    }
+}

--- a/alert/aria.test.ts
+++ b/alert/aria.test.ts
@@ -1,0 +1,8 @@
+import { makeAccessibleAlert } from "./aria";
+
+describe('makeAccessibleAlert function', () => {
+    it('applies the role attribute', () => {
+        const element: Element = makeAccessibleAlert(document.createElement('div'));
+        expect(element.getAttribute('role')).toEqual('alert');
+    });
+});

--- a/alert/aria.ts
+++ b/alert/aria.ts
@@ -1,0 +1,11 @@
+/**
+ * Applies accessibility attributes in accordance with the W3C WAI Alert Pattern.
+ * Refer to the W3C documentation https://www.w3.org/WAI/ARIA/apg/patterns/alert/.
+ * 
+ * @param alertElement 
+ * @returns Returns alertElement
+ */
+export function makeAccessibleAlert(alertElement: Element): Element {
+    alertElement.setAttribute('role', 'alert');
+    return alertElement;
+}

--- a/base/events.test.ts
+++ b/base/events.test.ts
@@ -1,0 +1,44 @@
+import { ClickEventDispatchInvoker, ClickMethodInvoker, DOMActionInvoker, FocusEventDispatchInvoker, FocusMethodInvoker } from "./events";
+
+describe('FocusMethodInvoker', () => {
+    it('invokes the focus method of an element.', () => {
+        const focusMethodInvoker: DOMActionInvoker = new FocusMethodInvoker();
+        const element: HTMLElement = document.createElement('button');
+        const focusSpy = jest.spyOn(element, 'focus');
+        focusMethodInvoker.invoke(element);
+        expect(focusSpy).toHaveBeenCalled();
+    });
+});
+describe('FocusEventDispatchInvoker', () => {
+    it('invokes the dispatchEvent method.', () => {
+        const invoker: DOMActionInvoker = new FocusEventDispatchInvoker();
+        const element: HTMLElement = document.createElement('button');
+        const dispatchEventSpy = jest.spyOn(element, 'dispatchEvent');
+        invoker.invoke(element);
+        expect(dispatchEventSpy).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'focus',
+        }));
+    });
+});
+describe('ClickMethodInvoker', () => {
+    it('invokes the click method.', () => {
+        const invoker: DOMActionInvoker = new ClickMethodInvoker();
+        const element: HTMLElement = document.createElement('button');
+        const clickSpy = jest.spyOn(element, 'click');
+        invoker.invoke(element);
+        expect(clickSpy).toHaveBeenCalled();
+    });
+});
+
+describe('ClickEventDispatchInvoker', () => {
+    it('invokes dispatchEvent', () => {
+        const invoker: DOMActionInvoker = new ClickEventDispatchInvoker();
+        const element: HTMLElement = document.createElement('button');
+        const dispatchEventSpy = jest.spyOn(element, 'dispatchEvent');
+        invoker.invoke(element);
+        expect(dispatchEventSpy).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'click',
+        }));
+    });
+});
+

--- a/base/events.ts
+++ b/base/events.ts
@@ -1,0 +1,41 @@
+import { identityFunction } from "./types";
+
+export type FocusChange = {
+    blurred: HTMLElement;
+    focused: HTMLElement;
+    blurredIndex: number;
+    focusedIndex: number;
+    elementCount: number;
+}
+
+export abstract class DOMActionInvoker {
+    public abstract invoke(element: HTMLElement): void;
+}
+
+export class FocusMethodInvoker extends DOMActionInvoker {
+    public invoke(element: HTMLElement): void {
+        element.focus();
+    }
+}
+
+export class FocusEventDispatchInvoker extends DOMActionInvoker {
+    public invoke(element: HTMLElement): void {
+        element.dispatchEvent(new FocusEvent('focus', {
+            bubbles: true,
+        }));
+    }
+}
+
+export class ClickMethodInvoker extends DOMActionInvoker {
+    public invoke(element: HTMLElement): void {
+        element.click();
+    }
+}
+
+export class ClickEventDispatchInvoker extends DOMActionInvoker {
+    public invoke(element: HTMLElement): void {
+        element.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+        }));
+    }
+}

--- a/base/types.test.ts
+++ b/base/types.test.ts
@@ -1,0 +1,346 @@
+import { AccessibleElementLabelViewModel, AccessibleElementLabelSelectorPreference, AccessibleElementSelectors, AccessibleElementViewModel } from "./types";
+import { identityFunction } from "./types";
+
+describe('identityFunction', () => {
+    it('returns its argument directly.', () => {
+        const value: string = 'mock identity arg';
+        expect(identityFunction(value)).toStrictEqual(value);
+
+        const referenceValue: string[] = ['mock', 'identity', 'value'];
+        expect(identityFunction(referenceValue)).toBe(referenceValue);
+    });
+});
+
+describe('AccessibleElementLabelViewModel', () => {
+    it('defines a default label id value.', () => {
+        expect(AccessibleElementLabelViewModel.DEFAULT_LABEL_ID).toBeDefined();
+        expect(typeof AccessibleElementLabelViewModel.DEFAULT_LABEL_ID).toEqual('string');
+        expect(AccessibleElementLabelViewModel.DEFAULT_LABEL_ID).toEqual('');
+    });
+    it('defines a default label text string.', () => {
+        expect(AccessibleElementLabelViewModel.DEFAULT_LABEL_TEXT).toBeDefined();
+        expect(typeof AccessibleElementLabelViewModel.DEFAULT_LABEL_TEXT).toEqual('string');
+        expect(AccessibleElementLabelViewModel.DEFAULT_LABEL_TEXT).toEqual('');
+    });
+    it('defines a default label element selector string.', () => {
+        expect(AccessibleElementLabelViewModel.DEFAULT_LABEL_ELEMENT_SELECTOR).toBeDefined();
+        expect(typeof AccessibleElementLabelViewModel.DEFAULT_LABEL_ELEMENT_SELECTOR).toEqual('string');
+        expect(AccessibleElementLabelViewModel.DEFAULT_LABEL_ELEMENT_SELECTOR).toEqual('');
+    });
+    it('defines a default selection preference.', () => {
+        expect(AccessibleElementLabelViewModel.DEFAULT_SELECTION_PREFERENCE).toBeDefined();
+        expect(AccessibleElementLabelViewModel.DEFAULT_SELECTION_PREFERENCE).toEqual(AccessibleElementLabelSelectorPreference.LABEL_ID);
+    });
+    it('defines a labelId property upon instantiation.', () => {
+        const labelId: string = 'label-id';
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+        );
+        expect(instance.labelId).toBeDefined();
+        expect(typeof instance.labelId).toEqual('string');
+        expect(instance.labelId).toEqual(labelId);
+    });
+    it('defines a labelId property with a default value upon instantiation.', () => {
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel();
+        expect(instance.labelId).toBeDefined();
+        expect(typeof instance.labelId).toEqual('string');
+        expect(instance.labelId).toStrictEqual(AccessibleElementLabelViewModel.DEFAULT_LABEL_ID);
+    });
+    it('defines a labelText property upon instantiation.', () => {
+        const labelText: string = 'label text';
+        const labelId: string = 'label id';
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(labelId, labelText);
+        expect(instance.labelText).toBeDefined();
+        expect(typeof instance.labelText).toEqual('string');
+        expect(instance.labelText).toStrictEqual(labelText);
+    });
+    it('defines a labelText property with a default value upon instantiation.', () => {
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel();
+        expect(instance.labelText).toStrictEqual(AccessibleElementLabelViewModel.DEFAULT_LABEL_TEXT);
+    });
+    it('defines a labelElementSelector property upon instantiation.', () => {
+        const selector: string = ':scope > label';
+        const labelId: string = 'label id';
+        const labelText: string = 'label text';
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            selector,
+        );
+        expect(instance.labelElementSelector).toBeDefined();
+        expect(typeof instance.labelElementSelector).toEqual('string');
+        expect(instance.labelElementSelector).toStrictEqual(selector);
+    });
+    it('defines a labelElementSelector property with a default value upon instantiation.', () => {
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel();
+        expect(instance.labelElementSelector).toBeDefined();
+        expect(typeof instance.labelElementSelector).toEqual('string');
+        expect(instance.labelElementSelector).toStrictEqual(AccessibleElementLabelViewModel.DEFAULT_LABEL_ELEMENT_SELECTOR);
+    });
+    it('defines a preference property upon instantiation.', () => {
+        const preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_ELEMENT_SELECTOR;
+        const labelId: string = 'label id';
+        const labelText: string = 'label text';
+        const selector: string = ':scope > label';
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            selector,
+            preference,
+        );
+        expect(instance.preference).toBeDefined();
+        expect(instance.preference).toStrictEqual(preference);
+    });
+    it('defines a preference property with a default value upon instantiation.', () => {
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel();
+        expect(instance.preference).toBeDefined();
+        expect(instance.preference).toEqual(AccessibleElementLabelViewModel.DEFAULT_SELECTION_PREFERENCE);
+    });
+    it('applies the label id to the aria-labelledby attribute.', () => {
+        const labelId: string = 'label-id';
+        const element: Element = document.createElement('div');
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(labelId);
+        const labelledById: string | null = AccessibleElementLabelViewModel.applyAccessibleLabel(element, instance).getAttribute('aria-labelledby');
+        expect(labelledById).toEqual(labelId);
+    });
+    it('applies the label text to the aria-label attribute.', () => {
+        const labelId: string = 'label-id';
+        const labelText: string = 'label text';
+        const labelSelector: string = ':scope > div:nth-of-type(1)';
+        const preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_TEXT
+        const element: Element = document.createElement('div');
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            labelSelector,
+            preference,
+        );
+        const label: string | null = AccessibleElementLabelViewModel.applyAccessibleLabel(element, instance).getAttribute('aria-label');
+        expect(label).toEqual(labelText);
+    });
+    it('applies the label id of the selected label element to the aria-labelledby attribute when all other options are provided and the preference is the selector.', () => {
+        const labelId: string = 'label-id';
+        const labelText: string = 'label text';
+        const labelSelector: string = ':scope > div:nth-of-type(1)';
+        const element: Element = document.createElement('div');
+        const labelElement: Element = document.createElement('div');
+        const preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_ELEMENT_SELECTOR;
+        labelElement.setAttribute('id', labelId);
+        element.appendChild(labelElement);
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            labelSelector,
+            preference,
+        );
+        const labelledById: string | null = AccessibleElementLabelViewModel.applyAccessibleLabel(element, instance).getAttribute('aria-labelledby');
+        expect(labelledById).toEqual(labelId);
+    });
+    it('applies the label id of the selected label element to the aria-labelledby attribute when no other options are provided.', () => {
+        const labelId: string = 'label-id';
+        const labelSelector: string = ':scope > div:nth-of-type(1)';
+        const element: Element = document.createElement('div');
+        const labelElement: Element = document.createElement('div');
+        const preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_ELEMENT_SELECTOR;
+        labelElement.setAttribute('id', labelId);
+        element.appendChild(labelElement);
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            '',
+            '',
+            labelSelector,
+            preference,
+        );
+        const labelledById: string | null = AccessibleElementLabelViewModel.applyAccessibleLabel(element, instance).getAttribute('aria-labelledby');
+        expect(labelledById).toEqual(labelId);
+    });
+    it('throws a ReferenceError when the selector does not identify a selectable element.', () => {
+        const labelId: string = 'label-id';
+        const labelText: string = 'label text';
+        const labelSelector: string = ':scope > img';
+        const preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_ELEMENT_SELECTOR;
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            labelSelector,
+            preference,
+        );
+        const element: Element = document.createElement('div');
+        expect(() => {
+            AccessibleElementLabelViewModel.applyAccessibleLabel(element, instance);
+        }).toThrow();
+    });
+    it('does not change aria-labelledby and aria-label when no id, text, or selector value is provided.', () => {
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel();
+        const element: Element = document.createElement('div');
+        AccessibleElementLabelViewModel.applyAccessibleLabel(element, instance);
+        const labelledById: string | null = element.getAttribute('aria-labelledby');
+        const label: string | null = element.getAttribute('aria-label');
+        expect(labelledById).toBeNull();
+        expect(label).toBeNull();
+    });
+    it('applies the aria-labelledby when both id and text are set with the id as the preference.', () => {
+        const labelId: string = 'label-id';
+        const labelText: string = 'label text';
+        const wrapperElement: Element = document.createElement('div');
+        const buttonElement: Element = document.createElement('button');
+        const labelElement: Element = document.createElement('div');
+        labelElement.setAttribute('id', labelId);
+        buttonElement.textContent = 'button text';
+        wrapperElement.append(buttonElement, labelElement);
+        const labelIdViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            undefined,
+            AccessibleElementLabelSelectorPreference.LABEL_ID,
+        );
+        AccessibleElementLabelViewModel.applyAccessibleLabel(wrapperElement, labelIdViewModel);
+        expect(wrapperElement.getAttribute('aria-labelledby')).toEqual(labelId);
+    });
+    it('applies the aria-labelledby attribute when id, text, and selectors are provided and the preference is for the id.', () => {
+        const labelId: string = 'label-id';
+        const labelText: string = 'label text';
+        const labelSelector: string = ':scope > label';
+        const preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_ID;
+        const wrapperElement: Element = document.createElement('div');
+        const buttonElement: Element = document.createElement('button');
+        const labelElement: Element = document.createElement('div');
+        labelElement.setAttribute('id', labelId);
+        buttonElement.textContent = 'button text';
+        wrapperElement.append(buttonElement, labelElement);
+        const instance: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            labelSelector,
+            preference,
+        );
+        AccessibleElementLabelViewModel.applyAccessibleLabel(wrapperElement, instance);
+        expect(wrapperElement.getAttribute('aria-labelledby')).toEqual(labelId);
+    });
+    it('applies the aria-label when both id and text are set with the text as the preference.', () => {
+        const labelId: string = 'label-id';
+        const labelText: string = 'label text';
+        const wrapperElement: Element = document.createElement('div');
+        const buttonElement: Element = document.createElement('button');
+        const labelElement: Element = document.createElement('div');
+        labelElement.setAttribute('id', labelId);
+        buttonElement.textContent = 'button text';
+        wrapperElement.append(buttonElement, labelElement);
+        const labelTextViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            '',
+            AccessibleElementLabelSelectorPreference.LABEL_TEXT,
+        );
+        AccessibleElementLabelViewModel.applyAccessibleLabel(wrapperElement, labelTextViewModel);
+        expect(wrapperElement.getAttribute('aria-label')).toEqual(labelText);
+    });
+    it('applies the aria-label attribute when only the label text is set.', () => {
+        const labelId: string = '';
+        const labelText: string = 'labe text';
+        const labelSelector: string = '';
+        const preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_TEXT;
+        const wrapperElement: Element = document.createElement('div');
+        const buttonElement: Element = document.createElement('button');
+        const labelElement: Element = document.createElement('div');
+        labelElement.setAttribute('id', labelId);
+        buttonElement.textContent = 'button text';
+        wrapperElement.append(buttonElement, labelElement);
+        const labelTextViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            labelId,
+            labelText,
+            labelSelector,
+            preference,
+        );
+        AccessibleElementLabelViewModel.applyAccessibleLabel(wrapperElement, labelTextViewModel);
+        expect(wrapperElement.getAttribute('aria-label')).toEqual(labelText);
+    });
+    it('returns an instance with default property values from its static factory function.', () => {
+        const instance: AccessibleElementLabelViewModel = AccessibleElementLabelViewModel.createDefault();
+        expect(instance.labelId).toStrictEqual(AccessibleElementLabelViewModel.DEFAULT_LABEL_ID);
+        expect(instance.labelText).toStrictEqual(AccessibleElementLabelViewModel.DEFAULT_LABEL_TEXT);
+        expect(instance.labelElementSelector).toStrictEqual(AccessibleElementLabelViewModel.DEFAULT_LABEL_ELEMENT_SELECTOR);
+        expect(instance.preference).toStrictEqual(AccessibleElementLabelViewModel.DEFAULT_SELECTION_PREFERENCE);
+    });
+});
+
+describe('AccessibleElementSelectors', () => {
+    it('defines a static default query root selector string.', () => {
+        expect(AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR).toBeDefined();
+        expect(typeof AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR).toEqual('string');
+        expect(AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR).toEqual('');
+    });
+    it('defines a static default accessible element selector string.', () => {
+        expect(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR).toBeDefined();
+        expect(typeof AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR).toEqual('string');
+        expect(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR).toEqual(':scope > div:nth-of-type(1)');
+    });
+    it('defines a queryRoot property string upon instantiation.', () => {
+        const rootSelector: string = ':scope > div';
+        const instance: AccessibleElementSelectors = new AccessibleElementSelectors(
+            rootSelector,
+        );
+        expect(instance.queryRoot).toBeDefined();
+        expect(typeof instance.queryRoot).toEqual('string');
+        expect(instance.queryRoot).toStrictEqual(rootSelector);
+    });
+    it('defines a queryRoot property with a default value upon instantiation.', () => {
+        const instance: AccessibleElementSelectors = new AccessibleElementSelectors();
+        expect(typeof instance.queryRoot).toEqual('string');
+        expect(instance.queryRoot).toStrictEqual(AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR);
+    });
+    it('defines an accessibleElement property string upon instantiation.', () => {
+        const rootSelector: string = ':scope > div';
+        const elementSelector: string = ':scope > div > div';
+        const instance: AccessibleElementSelectors = new AccessibleElementSelectors(
+            rootSelector,
+            elementSelector,
+        );
+        expect(instance.accessibleElement).toBeDefined();
+        expect(typeof instance.queryRoot).toEqual('string');
+        expect(instance.accessibleElement).toStrictEqual(elementSelector);
+    });
+    it('defines an acccessibleElement property string with a default value upon instantiation.', () => {
+        const instance: AccessibleElementSelectors = new AccessibleElementSelectors();
+        expect(instance.accessibleElement).toBeDefined();
+        expect(typeof instance.accessibleElement).toEqual('string');
+        expect(instance.accessibleElement).toStrictEqual(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR);
+    });
+});
+
+describe('AccessibleElementViewModel', () => {
+    class ViewModel extends AccessibleElementViewModel<AccessibleElementSelectors> {
+        public constructor(
+            selectors: AccessibleElementSelectors,
+            labelViewModel: AccessibleElementLabelViewModel,
+        ) {
+            super(selectors, labelViewModel);
+        }
+    }
+
+    it('defines a selectors property upon instantiation.', () => {
+        const rootSelector: string = ':scope > div';
+        const elementSelector: string = ':scope > div > div';
+        const selectors: AccessibleElementSelectors = new AccessibleElementSelectors(
+            rootSelector,
+            elementSelector,
+        );
+        const labelModel: AccessibleElementLabelViewModel = AccessibleElementLabelViewModel.createDefault();
+        const model: ViewModel = new ViewModel(selectors, labelModel);
+        expect(model.selectors).toBeDefined();
+        expect(model.selectors).toBeInstanceOf(AccessibleElementSelectors);
+        expect(model.selectors).toBe(selectors);
+    });
+    it('defines a labelViewModel property upon instnatiation.', () => {
+        const rootSelector: string = ':scope > div';
+        const elementSelector: string = ':scope > div > div';
+        const selectors: AccessibleElementSelectors = new AccessibleElementSelectors(
+            rootSelector,
+            elementSelector,
+        );
+        const labelModel: AccessibleElementLabelViewModel = AccessibleElementLabelViewModel.createDefault();
+        const model: ViewModel = new ViewModel(selectors, labelModel);
+        expect(model.labelViewModel).toBeDefined();
+        expect(model.labelViewModel).toBeInstanceOf(AccessibleElementLabelViewModel);
+        expect(model.labelViewModel).toBe(labelModel);
+    });
+});

--- a/base/types.test.ts
+++ b/base/types.test.ts
@@ -1,4 +1,4 @@
-import { AccessibleElementLabelViewModel, AccessibleElementLabelSelectorPreference, AccessibleElementSelectors, AccessibleElementViewModel } from "./types";
+import { AccessibleElementLabelViewModel, AccessibleElementLabelSelectorPreference, AccessibleElementSelectors, AccessibleElementViewModel, AccessibleElementDescriptionViewModel } from "./types";
 import { identityFunction } from "./types";
 
 describe('identityFunction', () => {
@@ -272,7 +272,7 @@ describe('AccessibleElementSelectors', () => {
     it('defines a static default accessible element selector string.', () => {
         expect(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR).toBeDefined();
         expect(typeof AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR).toEqual('string');
-        expect(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR).toEqual(':scope > div:nth-of-type(1)');
+        expect(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR).toEqual('');
     });
     it('defines a queryRoot property string upon instantiation.', () => {
         const rootSelector: string = ':scope > div';
@@ -305,6 +305,12 @@ describe('AccessibleElementSelectors', () => {
         expect(typeof instance.accessibleElement).toEqual('string');
         expect(instance.accessibleElement).toStrictEqual(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR);
     });
+    it('returns an instance with default values from its static factory.', () => {
+        const instance: AccessibleElementSelectors = AccessibleElementSelectors.createDefault();
+        expect(instance).toBeInstanceOf(AccessibleElementSelectors);
+        expect(instance.queryRoot).toEqual(AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR);
+        expect(instance.accessibleElement).toEqual(AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR);
+    });
 });
 
 describe('AccessibleElementViewModel', () => {
@@ -312,8 +318,9 @@ describe('AccessibleElementViewModel', () => {
         public constructor(
             selectors: AccessibleElementSelectors,
             labelViewModel: AccessibleElementLabelViewModel,
+            descriptionViewModel: AccessibleElementDescriptionViewModel,
         ) {
-            super(selectors, labelViewModel);
+            super(selectors, labelViewModel, descriptionViewModel);
         }
     }
 
@@ -325,7 +332,8 @@ describe('AccessibleElementViewModel', () => {
             elementSelector,
         );
         const labelModel: AccessibleElementLabelViewModel = AccessibleElementLabelViewModel.createDefault();
-        const model: ViewModel = new ViewModel(selectors, labelModel);
+        const descriptionViewModel: AccessibleElementDescriptionViewModel = AccessibleElementDescriptionViewModel.createDefault();
+        const model: ViewModel = new ViewModel(selectors, labelModel, descriptionViewModel);
         expect(model.selectors).toBeDefined();
         expect(model.selectors).toBeInstanceOf(AccessibleElementSelectors);
         expect(model.selectors).toBe(selectors);
@@ -338,9 +346,26 @@ describe('AccessibleElementViewModel', () => {
             elementSelector,
         );
         const labelModel: AccessibleElementLabelViewModel = AccessibleElementLabelViewModel.createDefault();
-        const model: ViewModel = new ViewModel(selectors, labelModel);
+        const descriptionViewModel: AccessibleElementDescriptionViewModel = AccessibleElementDescriptionViewModel.createDefault();
+        const model: ViewModel = new ViewModel(selectors, labelModel, descriptionViewModel);
         expect(model.labelViewModel).toBeDefined();
         expect(model.labelViewModel).toBeInstanceOf(AccessibleElementLabelViewModel);
         expect(model.labelViewModel).toBe(labelModel);
     });
+    it('defines a descriptionViewModel property upon instantiation.', () => {
+        const rootSelector: string = ':scope > div';
+        const elementSelector: string = ':scope > div > div';
+        const selectors: AccessibleElementSelectors = new AccessibleElementSelectors(
+            rootSelector,
+            elementSelector,
+        );
+        const labelModel: AccessibleElementLabelViewModel = AccessibleElementLabelViewModel.createDefault();
+        const descriptionViewModel: AccessibleElementDescriptionViewModel = AccessibleElementDescriptionViewModel.createDefault();
+        const model: ViewModel = new ViewModel(selectors, labelModel, descriptionViewModel);
+        expect(model.descriptionViewModel).toBeDefined();
+        expect(model.descriptionViewModel).toBeInstanceOf(AccessibleElementDescriptionViewModel);
+        expect(model.descriptionViewModel).toBe(descriptionViewModel);
+    });
+
+
 });

--- a/base/types.ts
+++ b/base/types.ts
@@ -61,6 +61,12 @@ export class AccessibleElementDescriptionViewModel {
 
     }
 
+    public static createDefault(): AccessibleElementDescriptionViewModel {
+        return new AccessibleElementDescriptionViewModel(
+            AccessibleElementDescriptionViewModel.DEFAULT_DESCRIBED_ELEMENT_SELECTOR,
+        );
+    }
+
     /**
      * Apply the state defined by the view model to a component DOM element.
      * @param rootElement The component DOM element for which to apply the view model state.
@@ -84,11 +90,11 @@ export class AccessibleElementDescriptionViewModel {
             // There is an element containging the description information.
             // Ensure there is an identifier, and an element to describe.
             const descriptionId: string = ensureElementHasID(descriptionElement);
-            const describedElement: Element | null = selectElementOrDefault(rootElement, describedElementSelector);
-            if (describedElement !== null) {
-                // Apply the ARIA description to the element.
-                describedElement.setAttribute('aria-describedby', descriptionId);
-            }
+            const describedElement: Element = selectElementOrDefault(rootElement, describedElementSelector);
+            
+            // Apply the ARIA description to the element.
+            describedElement.setAttribute('aria-describedby', descriptionId);
+            
         }
         return rootElement;
     }
@@ -234,7 +240,7 @@ export class AccessibleElementSelectors {
      * provided to be decorated with ARIA. An empty string is the default which indicates that the
      * Element instance itself is to serve as the root of the component DOM subtree from within the
      * accessible element can be identified for decoration.
-     * @default {""}
+     * @default ""
      */
     public static readonly DEFAULT_QUERY_ROOT_SELECTOR: string = '';
 
@@ -243,25 +249,31 @@ export class AccessibleElementSelectors {
      * The default value selects the first child <div> element.
      * @default {":scope > div:nth-of-type(1)"}
      */
-    public static readonly DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR: string = ':scope > div:nth-of-type(1)';
+    public static readonly DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR: string = '';
 
     public constructor(
 
         /**
          * DOM query selector string for identifying the component root element from which to select
          * the actual element to decorate with ARIA.
-         * @default {AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR}
+         * @default {AccessibleElementSelectors#DEFAULT_QUERY_ROOT_SELECTOR}
          */
         protected readonly queryRootSelector: string = AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR,
 
         /**
          * DOM query selector string for selecting the element within the root identifed by `queryRootSelector`
          * to decorate with ARIA.
-         * @default {AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR}
+         * @default {AccessibleElementSelectors#DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR}
          */
         protected readonly accessibleElementSelector: string = AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR,
-    ) {
+    ) {}
 
+    /**
+     * Return a new instance with default property values.
+     * @returns 
+     */
+    public static createDefault(): AccessibleElementSelectors {
+        return new AccessibleElementSelectors();
     }
 
     public get queryRoot(): string {
@@ -280,9 +292,8 @@ export abstract class AccessibleElementViewModel<SelectorType extends Accessible
     protected constructor(
         public readonly selectors: SelectorType,
         public readonly labelViewModel: AccessibleElementLabelViewModel,
-    ) {
-
-    }
+        public readonly descriptionViewModel: AccessibleElementDescriptionViewModel = AccessibleElementDescriptionViewModel.createDefault(),
+    ) {}
 }
 
 export type AccessibleElementInteractivityPatternState<

--- a/base/types.ts
+++ b/base/types.ts
@@ -1,0 +1,323 @@
+import { ensureElementHasID, selectElementOrDefault } from "../utils/dom";
+
+/**
+ * Abstraction of a function that accepts any number of arguments of any type, and returns any type.
+ * More generally speaking: a function.
+ */
+export type AnyKindOfFunction = (...args: any[]) => any;
+
+export type EventHandlerFunction<EventType> = (e: EventType) => void;
+
+/**
+ * Keyboard interactivity event callback function.
+ * Used when referring to an event handler for keyboard events.
+ */
+export type KeyEventCallback = (event: KeyboardEvent) => void;
+
+/**
+ * The identity function. A function that returns its argument.
+ * @param arg Identity subject.
+ * @returns The arg identity.
+ */
+export function identityFunction<T>(arg: T) {
+    return arg;
+}
+
+/**
+ * Preference for indicating which DOM structure component to refer to when creating the value
+ * for the aria-labelledby, or the aria-label attribute value.
+ * @see {AccessibleElementLabelViewModel}
+ */
+export enum AccessibleElementLabelSelectorPreference {
+    LABEL_ID,
+    LABEL_TEXT,
+    LABEL_ELEMENT_SELECTOR,
+}
+
+/**
+ * View model for defining how an element's ARIA description is determined.
+ */
+export class AccessibleElementDescriptionViewModel {
+
+    /**
+     * An empty string indicating that the described element is the root of the component DOM subtree
+     * without any subtree selelction necessary.
+     */
+    public static readonly DEFAULT_DESCRIBED_ELEMENT_SELECTOR: string = '';
+
+    public constructor(
+
+        /**
+         * DOM query selector string for referring to the element in the component DOM subtree that
+         * contains the component description. eg. `aria-describedby`
+         */
+        public readonly descriptionElementSelector: string,
+
+        /**
+         * DOM query selector string for referring to the element that is described. 
+         */
+        public readonly describedElementSelector: string = AccessibleElementDescriptionViewModel.DEFAULT_DESCRIBED_ELEMENT_SELECTOR,
+    ) {
+
+    }
+
+    /**
+     * Apply the state defined by the view model to a component DOM element.
+     * @param rootElement The component DOM element for which to apply the view model state.
+     * @returns The component DOM element.
+     */
+    public static applyDescribedBy(
+        rootElement: Element,
+        viewModel: AccessibleElementDescriptionViewModel,
+    ): Element {
+        const { 
+            descriptionElementSelector,
+            describedElementSelector,
+        } = viewModel;
+
+        if (!descriptionElementSelector) {
+            // There is no description so return the root unaffacted.
+            return rootElement;
+        }
+        const descriptionElement: Element | null = rootElement.querySelector(descriptionElementSelector);
+        if (descriptionElement) {
+            // There is an element containging the description information.
+            // Ensure there is an identifier, and an element to describe.
+            const descriptionId: string = ensureElementHasID(descriptionElement);
+            const describedElement: Element | null = selectElementOrDefault(rootElement, describedElementSelector);
+            if (describedElement !== null) {
+                // Apply the ARIA description to the element.
+                describedElement.setAttribute('aria-describedby', descriptionId);
+            }
+        }
+        return rootElement;
+    }
+}
+
+/**
+ * View model for defining how an element's AIRA label is determined.
+ */
+export class AccessibleElementLabelViewModel {
+
+    /**
+     * Default value for identifying the DOM element that will label the component.
+     * Empty string means unused in the view model.
+     * An empty string will result in no ARIA being applied if the preference value
+     * is AccessibleElementLabelSelectorPreference.LABEL_ID.
+     * @see {AccessibleElementLabelSelectorPreference}
+     */
+    public static readonly DEFAULT_LABEL_ID: string = '';
+
+    /**
+     * Default value for label text to be used as the string value for the `aria-label` 
+     * attribute of the component. Empty string means unused in the view model.
+     * An empty string will result in no ARIA being applied if the preference value
+     * is AccessibleElementLabelSelectorPreference.LABEL_TEXT.
+     * @see {AccessibleElementLabelSelectorPreference}
+     */
+    public static readonly DEFAULT_LABEL_TEXT: string = '';
+
+    /**
+     * Default value for selecting an element in the component DOM subtree to be used
+     * as identified element of the `aria-labelledby` attribute.
+     * An empty string means that it is unused in the view model.
+     * An empty string will result in no ARIA being applied if the prefernece is
+     * AccessibleElementLabelSelectorPreference.LABEL_ELEMENT_SELECTOR.
+     * @see {AccessibleElementLabelSelectorPreference}
+     */
+    public static readonly DEFAULT_LABEL_ELEMENT_SELECTOR: string = '';
+
+    /**
+     * Default value for indicating which of the view model state indicators is to be used
+     * for resolving the component label. The default value is 
+     * AccessibleElementLabelSelectorPreference.LABEL_ID indicating that the `labelId` property
+     * identifies an element whos `id` attribute will be used with the `aria-labelledby` attribute
+     * on the component.
+     * @see {AccessibleElementLabelSelectorPreference}
+     */
+    public static readonly DEFAULT_SELECTION_PREFERENCE: AccessibleElementLabelSelectorPreference = AccessibleElementLabelSelectorPreference.LABEL_ID;
+
+    constructor(
+
+        /**
+         * Identifier of the labelling element, or an empty string if either `labelText`, 
+         * or `labelElementSelector` is used.
+         * @default {AccessibleElementLabelViewModel.DEFAULT_LABEL_ID}
+         */
+        public readonly labelId: string = AccessibleElementLabelViewModel.DEFAULT_LABEL_ID,
+
+        /**
+         * Label text string to be applied to the `aria-label` attribute, or an empty string
+         * if either `labelId`, or `labelElementSelector` is used.
+         * @default {AccessibleElementLabelViewModel.DEFAULT_LABEL_TEXT}
+         */
+        public readonly labelText: string = AccessibleElementLabelViewModel.DEFAULT_LABEL_TEXT,
+
+        /**
+         * DOM query selector string used to select the labelling element in the component DOM
+         * subtree, or an empty string if either `labelId`, or `labelText` is used.
+         * @default {AccessibleElementLabelViewModel.DEFAULT_LABEL_ELEMENT_SELECTOR}
+         */
+        public readonly labelElementSelector: string = AccessibleElementLabelViewModel.DEFAULT_LABEL_ELEMENT_SELECTOR,
+
+        /**
+         * An enum contant indicating which of the instance properties contains the valid value used
+         * for determining the label ARIA.
+         * @default {AccessibleElementLabelViewModel.DEFAULT_SELECTION_PREFERENCE}
+         * @see {AccessibleElementLabelSelectorPreference}
+         */
+        public readonly preference: AccessibleElementLabelSelectorPreference = AccessibleElementLabelViewModel.DEFAULT_SELECTION_PREFERENCE,
+    ) {
+
+    }
+
+    static applyAccessibleLabel(element: Element, viewModel: AccessibleElementLabelViewModel): Element {
+        const { 
+            labelId, 
+            labelText, 
+            labelElementSelector, 
+            preference,
+        } = viewModel;
+        const assignByLabelId = (id: string = labelId) => {
+            element.setAttribute('aria-labelledby', id);
+        };
+        const assignByLabelText = (text: string = labelText) => {
+            element.setAttribute('aria-label', text);
+        };
+        const assignLabelBySelector = (selector: string = labelElementSelector) => {
+            const labelElement: Element | null = element.querySelector(labelElementSelector);
+            if (labelElement) {
+                const id: string = ensureElementHasID(labelElement);
+                assignByLabelId(id);
+            } else {
+                throw new ReferenceError(`Label element selector does not identify an existing Element: ${selector}`);
+            }
+        };
+
+        if (labelId !== '' && labelText !== '' && labelElementSelector !== '') {
+            if (preference === AccessibleElementLabelSelectorPreference.LABEL_ID) {
+                assignByLabelId();
+            } else if (preference === AccessibleElementLabelSelectorPreference.LABEL_TEXT) {
+                assignByLabelText();
+            } else if (preference === AccessibleElementLabelSelectorPreference.LABEL_ELEMENT_SELECTOR) {
+                assignLabelBySelector();
+            }
+        } else if (labelId !== '' && labelText !== '') {
+            if (preference === AccessibleElementLabelSelectorPreference.LABEL_ID) {
+                assignByLabelId();
+            } else if (preference === AccessibleElementLabelSelectorPreference.LABEL_TEXT) {
+                assignByLabelText();
+            }
+        } else if (labelId !== '') {
+            assignByLabelId(labelId);
+        } else if (labelText !== '') {
+            assignByLabelText();
+        } else if (labelElementSelector !== '') {
+            assignLabelBySelector();
+        }
+        return element;
+    }
+
+    public static createDefault(): AccessibleElementLabelViewModel {
+        return new AccessibleElementLabelViewModel();
+    }
+}
+
+/**
+ * Defines the values necessary for determing how to select the accessible component to apply ARIA relative
+ * to the Element, or HTMLElement decorated by one of the library's component functions.
+ */
+export class AccessibleElementSelectors {
+    
+    /**
+     * Default value for the root of the component DOM subtree relative to the DOM Element instance
+     * provided to be decorated with ARIA. An empty string is the default which indicates that the
+     * Element instance itself is to serve as the root of the component DOM subtree from within the
+     * accessible element can be identified for decoration.
+     * @default {""}
+     */
+    public static readonly DEFAULT_QUERY_ROOT_SELECTOR: string = '';
+
+    /**
+     * Default value for the accessible element DOM query selector string relative to the root selector.
+     * The default value selects the first child <div> element.
+     * @default {":scope > div:nth-of-type(1)"}
+     */
+    public static readonly DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR: string = ':scope > div:nth-of-type(1)';
+
+    public constructor(
+
+        /**
+         * DOM query selector string for identifying the component root element from which to select
+         * the actual element to decorate with ARIA.
+         * @default {AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR}
+         */
+        protected readonly queryRootSelector: string = AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR,
+
+        /**
+         * DOM query selector string for selecting the element within the root identifed by `queryRootSelector`
+         * to decorate with ARIA.
+         * @default {AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR}
+         */
+        protected readonly accessibleElementSelector: string = AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR,
+    ) {
+
+    }
+
+    public get queryRoot(): string {
+        return this.queryRootSelector;
+    }
+
+    public get accessibleElement(): string {
+        return this.accessibleElementSelector;
+    }
+}
+
+/**
+ * 
+ */
+export abstract class AccessibleElementViewModel<SelectorType extends AccessibleElementSelectors> {
+    protected constructor(
+        public readonly selectors: SelectorType,
+        public readonly labelViewModel: AccessibleElementLabelViewModel,
+    ) {
+
+    }
+}
+
+export type AccessibleElementInteractivityPatternState<
+    SelectorType extends AccessibleElementSelectors, 
+    ViewModelType extends AccessibleElementViewModel<SelectorType>,
+    EventType extends Event,
+> = {
+    element: HTMLElement;
+    viewModel: ViewModelType;
+    handler: EventHandlerFunction<EventType>;
+}
+
+
+export abstract class InteractiveAccessibleElement<
+    SelectorType extends AccessibleElementSelectors, 
+    ViewModelType extends AccessibleElementViewModel<SelectorType>,
+    EventType extends Event,
+> {
+
+    protected constructor(
+        protected patternState: AccessibleElementInteractivityPatternState<SelectorType, ViewModelType, EventType> | null = null,
+    ) {}
+
+    public get interactivityState(): AccessibleElementInteractivityPatternState<SelectorType, ViewModelType, EventType> | null {
+        return this.patternState;
+    }
+
+    public abstract initializeInteractiveState(
+        element: HTMLElement,
+        viewModel: ViewModelType,
+    ): boolean;
+
+    public abstract attachEventHandler(): boolean;
+
+    public abstract removeEventHandler(): boolean;
+
+    public abstract cleanupHandlerState(): boolean;
+}

--- a/breadcrumbs/aria.test.ts
+++ b/breadcrumbs/aria.test.ts
@@ -1,0 +1,86 @@
+import { AccessibleElementDescriptionViewModel, AccessibleElementLabelViewModel } from "../base/types";
+import { createElementID } from "../utils/dom";
+import { makeAccessibleBreadcrumbs } from "./aria";
+import { AccessibleBreadcrumbsViewModel, BreadcrumbsElementSelectorSet } from "./types";
+
+describe('makeAccessibleBreadcrumbs function', () => {
+    const anchorElementsSpec: string[] = [
+        'https://fake.com/page/1/',
+        'https://fake.com/page/2',
+    ];
+    const createElement: () => Element = () => {
+        const navigationElement: Element = document.createElement('nav');
+        const labelElement: Element = document.createElement('h3');
+        const listElement: Element = document.createElement('ul');
+        const anchorListElements: Element[] = anchorElementsSpec.map((linkUrl: string) => {
+            const listItemElement: Element = document.createElement('li');
+            const anchorElement: Element = document.createElement('a');
+            anchorElement.setAttribute('href', linkUrl);
+            listItemElement.append(anchorElement);
+            return listItemElement;
+        });
+        listElement.append(...anchorListElements);
+        navigationElement.append(labelElement);
+        navigationElement.append(listElement);
+        return navigationElement;
+    };
+    it('applies the aria-label attribute when specified.', () => {
+        const labelText: string = 'fake label text';
+        const labelViewModel: AccessibleElementLabelViewModel = new AccessibleElementLabelViewModel(
+            '',
+            labelText,
+        );
+        const viewModel: AccessibleBreadcrumbsViewModel = new AccessibleBreadcrumbsViewModel(
+            AccessibleBreadcrumbsViewModel.DEFAULT_CURRENT_PAGE_DETERMINATION,
+            BreadcrumbsElementSelectorSet.createDefault(),
+            labelViewModel,
+            AccessibleElementDescriptionViewModel.createDefault(),
+        );
+        const element: Element = makeAccessibleBreadcrumbs(createElement(), viewModel);
+        expect(element.getAttribute('aria-label')).toEqual(labelText);
+    });
+    it('applies a default aria-label attribute when not specifiec.', () => {
+        const viewModel: AccessibleBreadcrumbsViewModel = AccessibleBreadcrumbsViewModel.createDefault();
+        const element: Element = makeAccessibleBreadcrumbs(createElement(), viewModel);
+        expect(element.getAttribute('aria-label')).toEqual(AccessibleBreadcrumbsViewModel.DEFAULT_LABEL);        
+    });
+    it('applies the aria-labelledby attribute.', () => {
+        const viewModel: AccessibleBreadcrumbsViewModel = new AccessibleBreadcrumbsViewModel(
+            AccessibleBreadcrumbsViewModel.DEFAULT_CURRENT_PAGE_DETERMINATION,
+            BreadcrumbsElementSelectorSet.createDefault(),
+            new AccessibleElementLabelViewModel(
+                createElementID(
+                    AccessibleBreadcrumbsViewModel.LABEL_ID_PREFIX,
+                    AccessibleBreadcrumbsViewModel.LABEL_ID_SUFFIX,
+                ),
+            ),
+            AccessibleElementDescriptionViewModel.createDefault(),
+        );
+        const element: Element = createElement();
+        element.querySelector('h3')?.setAttribute?.('id', viewModel.labelViewModel.labelId as string);
+        makeAccessibleBreadcrumbs(
+            element,
+            viewModel,
+        );
+        expect(element.getAttribute('aria-labelledby')).toEqual(viewModel.labelViewModel.labelId);
+    });
+    it('applies the aria-current attribute to the correct anchor element.', () => {
+        const isLinkCurrentPage = (linkUrl: string) => linkUrl === anchorElementsSpec[0];
+        const viewModel: AccessibleBreadcrumbsViewModel = new AccessibleBreadcrumbsViewModel(
+            isLinkCurrentPage,
+            BreadcrumbsElementSelectorSet.createDefault(),
+            new AccessibleElementLabelViewModel(),
+            AccessibleElementDescriptionViewModel.createDefault(),
+        );
+        const element: Element = makeAccessibleBreadcrumbs(createElement(), viewModel);
+        const anchorSelector: string = ':scope ul a:nth-of-type(1)';
+        const anchorElement: Element | null = element.querySelector(anchorSelector);
+        expect(anchorElement).not.toBeNull();
+        expect(anchorElement?.getAttribute('aria-current')).toEqual('page');
+    });
+    it('uses a default view model.', () => {
+        const breadcrumbsElement: Element = createElement();
+        const madeAccessibleBreadcrumbs: Element = makeAccessibleBreadcrumbs(breadcrumbsElement);
+        expect(madeAccessibleBreadcrumbs).toBe(breadcrumbsElement);
+    });
+});

--- a/breadcrumbs/aria.ts
+++ b/breadcrumbs/aria.ts
@@ -1,0 +1,37 @@
+import { AccessibleElementLabelViewModel } from "../base/types";
+import { selectElementOrDefault } from "../utils/dom";
+import { AccessibleBreadcrumbsViewModel } from "./types";
+
+/**
+ * Applies ARIA to a DOM Element in accordance with the Breadcrumbs pattern defined at
+ * https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/
+ * @param breadcrumbsElement Breadcrumbs component root DOM Element.
+ * @param viewModel Breadcrumbs component accessibility options.
+ * @returns Returns the component decorated with appropriate ARIA.
+ * @see {https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/}
+ */
+export function makeAccessibleBreadcrumbs(
+    breadcrumbsElement: Element,
+    viewModel: AccessibleBreadcrumbsViewModel = AccessibleBreadcrumbsViewModel.createDefault(),
+): Element {
+    const {
+        selectors,
+        isLinkCurrentPage,
+        labelViewModel,
+    } = viewModel;
+    const navigationElement: Element | null = selectElementOrDefault(breadcrumbsElement, selectors.navigationSelector);
+    const anchorElements: NodeList = breadcrumbsElement.querySelectorAll(selectors.anchorSelector);
+
+    AccessibleElementLabelViewModel.applyAccessibleLabel(navigationElement as Element, labelViewModel);
+
+    if (anchorElements.length > 0) {
+        const currentPageAnchorElement: Node | undefined = Array.from(anchorElements).find(node => (
+            isLinkCurrentPage((node as Element).getAttribute('href') as string)
+        ));
+        if(currentPageAnchorElement) {
+            (currentPageAnchorElement as Element).setAttribute('aria-current', 'page');
+        }
+    }
+
+    return breadcrumbsElement;
+}

--- a/breadcrumbs/types.test.ts
+++ b/breadcrumbs/types.test.ts
@@ -1,0 +1,80 @@
+import { AccessibleElementLabelViewModel } from "../base/types";
+import { AccessibleBreadcrumbsViewModel, BreadcrumbsElementSelectorSet } from "./types";
+
+describe('BreadcrumbsElementSelectorSet', () => {
+    it('defines a default navigation selector string.', () => {
+        expect(BreadcrumbsElementSelectorSet.DEFAULT_NAVIGATION_SELECTOR).toBeDefined();
+        expect(typeof BreadcrumbsElementSelectorSet.DEFAULT_NAVIGATION_SELECTOR).toEqual('string');
+        expect(BreadcrumbsElementSelectorSet.DEFAULT_NAVIGATION_SELECTOR.trim()).not.toEqual('');
+    });
+    it('defines a default anchor selector string.', () => {
+        expect(BreadcrumbsElementSelectorSet.DEFAULT_ANCHOR_SELECTOR).toBeDefined();
+        expect(typeof BreadcrumbsElementSelectorSet.DEFAULT_ANCHOR_SELECTOR).toEqual('string');
+        expect(BreadcrumbsElementSelectorSet.DEFAULT_ANCHOR_SELECTOR.trim()).not.toEqual('');
+    });
+    it('defines a navigation selector property upon instantiation.', () => {
+        const instance: BreadcrumbsElementSelectorSet = new BreadcrumbsElementSelectorSet(
+            BreadcrumbsElementSelectorSet.DEFAULT_NAVIGATION_SELECTOR,
+            BreadcrumbsElementSelectorSet.DEFAULT_ANCHOR_SELECTOR,
+        );
+        expect(instance.navigationSelector).toEqual(BreadcrumbsElementSelectorSet.DEFAULT_NAVIGATION_SELECTOR);
+    });
+    it('defines an anchor selector property upon instantiation.', () => {
+        const instance: BreadcrumbsElementSelectorSet = new BreadcrumbsElementSelectorSet(
+            BreadcrumbsElementSelectorSet.DEFAULT_NAVIGATION_SELECTOR,
+            BreadcrumbsElementSelectorSet.DEFAULT_ANCHOR_SELECTOR,
+        );
+        expect(instance.anchorSelector).toEqual(BreadcrumbsElementSelectorSet.DEFAULT_ANCHOR_SELECTOR);
+    });
+    it('returns an instance with the defualt navigation, and anchor selectors from createDefault.', () => {
+        const instance: BreadcrumbsElementSelectorSet = BreadcrumbsElementSelectorSet.createDefault();
+        expect(instance.navigationSelector).toEqual(BreadcrumbsElementSelectorSet.DEFAULT_NAVIGATION_SELECTOR);
+        expect(instance.anchorSelector).toEqual(BreadcrumbsElementSelectorSet.DEFAULT_ANCHOR_SELECTOR);
+    });
+});
+
+describe('AccessibleBreadcrumbsViewModel class', () => {
+    it('defines a default label id prefix string.', () => {
+        expect(AccessibleBreadcrumbsViewModel.LABEL_ID_PREFIX).toBeDefined();
+        expect(typeof AccessibleBreadcrumbsViewModel.LABEL_ID_PREFIX).toEqual('string');
+        expect(AccessibleBreadcrumbsViewModel.LABEL_ID_PREFIX.trim()).not.toEqual('');
+    });
+    it('defines a default labe id suffix string.', () => {
+        expect(AccessibleBreadcrumbsViewModel.LABEL_ID_SUFFIX).toBeDefined();
+        expect(typeof AccessibleBreadcrumbsViewModel.LABEL_ID_SUFFIX).toEqual('string');
+        expect(AccessibleBreadcrumbsViewModel.LABEL_ID_SUFFIX).not.toEqual('');
+    });
+    it('defines a default breadcrumbs label string.', () => {
+        expect(AccessibleBreadcrumbsViewModel.DEFAULT_LABEL).toBeDefined();
+        expect(typeof AccessibleBreadcrumbsViewModel.DEFAULT_LABEL).toEqual('string');
+        expect(AccessibleBreadcrumbsViewModel.DEFAULT_LABEL.trim()).not.toEqual('');
+    });
+    it('defines a default current page determination function.', () => {
+        expect(AccessibleBreadcrumbsViewModel.DEFAULT_CURRENT_PAGE_DETERMINATION).toBeDefined();
+        expect(typeof AccessibleBreadcrumbsViewModel).toEqual('function');
+    });
+    it('defines a selectors property upon instantiation.', () => {
+        const instance: AccessibleBreadcrumbsViewModel = AccessibleBreadcrumbsViewModel.createDefault();
+        expect(instance.selectors).toBeDefined();
+        expect(instance.selectors).not.toBeNull();
+        expect(instance.selectors instanceof BreadcrumbsElementSelectorSet).toEqual(true);
+    });
+    it('defines a breadcrumbs label view model upon instantiation.', () => {
+        const instance: AccessibleBreadcrumbsViewModel = AccessibleBreadcrumbsViewModel.createDefault();
+        expect(instance.labelViewModel).toBeDefined();
+        expect(instance.labelViewModel).not.toBeNull();
+        expect(instance.labelViewModel instanceof AccessibleElementLabelViewModel).toEqual(true);
+    });
+    it('defines an is current page getter property upon instantiation.', () => {
+        const instance: AccessibleBreadcrumbsViewModel = AccessibleBreadcrumbsViewModel.createDefault();
+        expect(instance.isLinkCurrentPage).toBeDefined();
+        expect(instance.isLinkCurrentPage).not.toBeNull();
+        expect(typeof instance.isLinkCurrentPage).toEqual('function');
+    });
+    it('creates an instance with default values.', () => {
+        const instance: AccessibleBreadcrumbsViewModel = AccessibleBreadcrumbsViewModel.createDefault();
+        expect(instance).toBeDefined();
+        expect(instance).not.toBeNull();
+        expect(instance instanceof AccessibleBreadcrumbsViewModel).toEqual(true);
+    });
+});

--- a/breadcrumbs/types.ts
+++ b/breadcrumbs/types.ts
@@ -1,0 +1,96 @@
+import { 
+    AccessibleElementDescriptionViewModel,
+    AccessibleElementLabelSelectorPreference,
+    AccessibleElementLabelViewModel,
+    AccessibleElementSelectors,
+    AccessibleElementViewModel,
+} from "../base/types";
+import { windowLocationIncludesUrl } from "../utils/dom";
+
+export class BreadcrumbsElementSelectorSet extends AccessibleElementSelectors {
+
+    /**
+     * Default navigation selector string expects a <nav> element which is
+     * a landmark element by default.
+     * @value ":scope > nav"
+     * @constant
+     */
+    public static readonly DEFAULT_NAVIGATION_SELECTOR = ':scope > nav';
+
+    /**
+     * Default navigation anchor NodeList selector string expects a collection of
+     * <a> elements directo or indirect children of <li> elements.
+     * @value ":scope li a"
+     * @constant
+     */
+    public static readonly DEFAULT_ANCHOR_SELECTOR = ':scope li a';
+    
+    constructor(
+
+        /**
+         * Query selector string for the <nav> element within the component.
+         * Defines the labeled landmark element to apply aria-label, or aria-labelledby.
+         * @see {BreadcrumbsElementSelectorSet#DEFAULT_NAVIGATION_SELECTOR}
+         */
+        public readonly navigationSelector: string,
+
+        /**
+         * Query selector string for the anchor elements.
+         * Used to determine which requires `aria-current`.
+         * @see {BreadcrumbsElementSelectorSet#DEFAULT_ANCHOR_SELECTOR}
+         */
+        public readonly anchorSelector: string,
+
+        /**
+         * @see {AccessibleElementSelectors#constructor}
+         */
+        protected readonly queryRootSelector: string = AccessibleElementSelectors.DEFAULT_QUERY_ROOT_SELECTOR,
+
+        /**
+         * @see {AccessibleElementSelectors#constructor}
+         */
+        protected readonly accessibleElementSelector: string = AccessibleElementSelectors.DEFAULT_ACCESSIBLE_ELEMENT_SELECTOR,
+    ) {
+        super(queryRootSelector, accessibleElementSelector);
+    }
+    
+    public static createDefault(): BreadcrumbsElementSelectorSet {
+        return new BreadcrumbsElementSelectorSet(
+            this.DEFAULT_NAVIGATION_SELECTOR,
+            this.DEFAULT_ANCHOR_SELECTOR,
+        );
+    }
+}
+
+
+export class AccessibleBreadcrumbsViewModel extends AccessibleElementViewModel<BreadcrumbsElementSelectorSet> {
+
+    public static readonly LABEL_ID_PREFIX: string = 'breadcrumb-';
+    public static readonly LABEL_ID_SUFFIX: string = '-landmark';
+    public static readonly DEFAULT_LABEL: string = 'Breadcrumb';
+    public static readonly DEFAULT_CURRENT_PAGE_DETERMINATION: (linkUrl: string) => boolean = windowLocationIncludesUrl;
+
+    constructor(
+        public readonly isLinkCurrentPage: (linkUrl: string) => boolean,
+        public selectors: BreadcrumbsElementSelectorSet,
+        public labelViewModel: AccessibleElementLabelViewModel,
+        public descriptionViewModel: AccessibleElementDescriptionViewModel,
+    ) {
+        super(selectors, labelViewModel, descriptionViewModel);
+    }
+
+    public static createDefault(): AccessibleBreadcrumbsViewModel {
+        const instance: AccessibleBreadcrumbsViewModel = new AccessibleBreadcrumbsViewModel(
+            AccessibleBreadcrumbsViewModel.DEFAULT_CURRENT_PAGE_DETERMINATION,
+            BreadcrumbsElementSelectorSet.createDefault(),
+            new AccessibleElementLabelViewModel(
+                undefined,
+                this.DEFAULT_LABEL,
+                undefined,
+                AccessibleElementLabelSelectorPreference.LABEL_TEXT,
+            ),
+            AccessibleElementDescriptionViewModel.createDefault(),
+        );
+        return instance;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,7 @@
 {
+  "extends": "./tsconfig.json",
   "include": [
-    "./*.ts",
-  ],
-  "exclude": [
-    "./*.test.ts",
+    "./**/*.ts",
   ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,6 +1,6 @@
 {
     "include": [
-      "./*.test.ts",
+      "./**/*.test.ts",
     ],
     "compilerOptions": {
       /* Visit https://aka.ms/tsconfig to read more about this file */

--- a/utils.ts
+++ b/utils.ts
@@ -224,6 +224,7 @@ export function nextWrapAroundIndex<CollectionElementType>(
         }
     }
 }
+
 export function queryChildren(parentElement: Element, selectors: string[]): (Element | null)[] {
     const elements: (Element | null)[] = selectors.map((selector: string) => {
         const element: Element | null = parentElement.querySelector(selector);

--- a/utils/collections.test.ts
+++ b/utils/collections.test.ts
@@ -1,0 +1,34 @@
+import { nextWrapAroundIndex, WrapAroundDirection } from "./collections";
+
+describe('The nextWrapAroundIndex function', () => {
+
+    const collection: string[] = ['First', 'Next', 'Last'];
+
+    it('returns the next index through entire collection.', () => {
+        expect(collection.length).toBeGreaterThan(1);
+        for (let i: number = 0; i < collection.length - 1; ++i) {
+            const nextIndex: number = nextWrapAroundIndex(collection, i, WrapAroundDirection.NEXT);
+            expect(nextIndex).toEqual(i + 1);
+        }
+    });
+    it('returns the wrap around to zero index after the last index.', () => {
+        const currentIndex: number = collection.length - 1;
+        const expectedIndex: number = 0;
+        const nextIndex: number = nextWrapAroundIndex(collection, currentIndex, WrapAroundDirection.NEXT);
+        expect(nextIndex).toEqual(expectedIndex);
+    });
+    it('returns the previous index through the entire collection from the end.', () => {
+        expect(collection.length).toBeGreaterThan(1);
+        for (let i: number = collection.length; i > 0; --i) {
+            const previousIndex: number = nextWrapAroundIndex(collection, i, WrapAroundDirection.PREVIOUS);
+            const expectedIndex: number = i - 1;
+            expect(previousIndex).toEqual(expectedIndex);
+        }
+    });
+    it('returns the wrap around to length-1 index before the first index.', () => {
+        expect(collection.length).toBeGreaterThan(1);
+        const currentIndex: number = 0;
+        const previousIndex: number = nextWrapAroundIndex(collection, currentIndex, WrapAroundDirection.PREVIOUS);
+        const expectedIndex: number = collection.length - 1;
+    });
+});

--- a/utils/collections.ts
+++ b/utils/collections.ts
@@ -1,0 +1,24 @@
+export enum WrapAroundDirection {
+    NEXT,
+    PREVIOUS,
+}
+
+export function nextWrapAroundIndex<CollectionElementType>(
+    collection: CollectionElementType[],
+    currentIndex: number,
+    direction: WrapAroundDirection,
+): number {
+    if (direction === WrapAroundDirection.NEXT) {
+        if (currentIndex < (collection.length - 1)) {
+            return currentIndex + 1;
+        } else {
+            return 0;
+        }
+    } else {
+        if (currentIndex > 0) {
+            return currentIndex - 1;
+        } else {
+            return collection.length - 1;
+        }
+    }
+}

--- a/utils/dom.test.ts
+++ b/utils/dom.test.ts
@@ -1,0 +1,397 @@
+import { AccessibleElementDescriptionViewModel } from "../base/types";
+import { createElementID, determineLandmarkRole, ensureElementHasID, interceptClick, isButtonElement, queryChildren, selectElementOrDefault, targetElementIsToggleButton, toggleExpandedHiddenState, windowLocationIncludesUrl } from "./dom";
+
+describe('createElementID function', () => {
+    it('returns a string with a specified prefix.', () => {
+        const mockPrefix: string = 'prefix';
+        const elementID: string = createElementID(mockPrefix);
+        expect(elementID.startsWith(mockPrefix)).toBeTruthy();
+    });
+    it('returns a string with a specified suffix.', () => {
+        const mockSuffix: string = 'suffix';
+        const elementID: string = createElementID('', mockSuffix);
+        expect(elementID.endsWith(mockSuffix)).toBeTruthy();
+    });
+    it('returns a random UUID.', () => {
+        const elementID: string = createElementID();
+        const pattern: RegExp = /^([a-z0-9]+-*)+([a-z0-9]+)$/i;
+        const patternMatched: boolean = pattern.test(elementID);
+        expect(patternMatched).toBeTruthy();
+    });
+});
+
+describe('ensureElementHasID function', () => {
+    const createElement: (...id: string[]) => Element = (id: string = '') => {
+        const element: Element = document.createElement('div');
+        if (id !== '') {
+            element.setAttribute('id', id);
+        }
+        return element;
+    };
+    it('returns the value of the existing id attribute.', () => {
+        const mockID: string = 'mock-id';
+        const element: Element = createElement(mockID);
+        const ensuredElementID: string = ensureElementHasID(element);
+        expect(ensuredElementID).toEqual(mockID);
+    });
+    it('returns an ID using the supplied ID generation function.', () => {
+        const mockID: string = 'mock-id';
+        const idGenerator = () => mockID;
+        const element: Element = createElement();
+        const ensuredElementID: string = ensureElementHasID(element, idGenerator);
+        expect(ensuredElementID).toEqual(mockID);
+    });
+    it('returns an ID that is also applied to the element.', () => {
+        const element: Element = createElement();
+        const ensuredElementID: string = ensureElementHasID(element);
+        expect(ensuredElementID).not.toEqual('');
+        expect(element.hasAttribute('id')).toBeTruthy();
+        expect(element.getAttribute('id')).toEqual(ensuredElementID);
+    });
+});
+
+describe('The targetElementIsToggleButton function', () => {
+    type MockToggleButtonAttributes = {
+        role?: string;
+        control?: string;
+        expanded?: string;
+    }
+
+    const createElement: (attributes: MockToggleButtonAttributes) => Element = (attributes: MockToggleButtonAttributes): Element => {
+        const element: Element = document.createElement('button');
+        if (attributes.role !== '') {
+            const { role = '' } = attributes;
+            element.setAttribute('role', role);
+        }
+        if (attributes.control !== '') {
+            const { control = '' } = attributes;
+            element.setAttribute('aria-controls', control);
+        }
+        if (attributes.expanded !== '') {
+            const { expanded = '' } = attributes;
+            element.setAttribute('aria-expanded', expanded);
+        }
+        return element;
+    };
+
+    it('correctly identifies a toggle button.', () => {
+        const element: Element = createElement({
+            role: 'button',
+            control: 'foo',
+            expanded: 'true',
+        });
+        const isToggleButton: boolean = targetElementIsToggleButton(element as EventTarget);
+        expect(isToggleButton).toEqual(true);
+    });
+    it('correctly identifies what is not a toggle button without the button role.', () => {
+        const element: Element = createElement({
+            control: '',
+            expanded: '',
+        });
+        const isToggleButton: boolean = targetElementIsToggleButton(element as EventTarget);
+        expect(isToggleButton).toEqual(false);
+    });
+    it('correctly identifies what is not a toggle button that does not control something else.', () => {
+        const element: Element = createElement({
+            role: '',
+            expanded: '',
+        });
+        const isToggleButton: boolean = targetElementIsToggleButton(element as EventTarget);
+        expect(isToggleButton).toEqual(false);
+    });
+    it('correctly identifies what is not a toggle button that does not expand collapse something else.', () => {
+        const element: Element = createElement({
+            role: '',
+            control: '',
+        });
+        const isToggleButton: boolean = targetElementIsToggleButton(element as EventTarget);
+        expect(isToggleButton).toEqual(false);
+    });
+});
+
+describe('toggleExpandedHiddenState function', () => {
+    const createToggleWithControlled: () => Element = () => {
+        const rootElement: Element = document.createElement('div');
+        const headingElement: Element = document.createElement('h3');
+        const toggleElement: Element = document.createElement('button');
+        const controlledElement: Element = document.createElement('div');
+
+        toggleElement.setAttribute('aria-expanded', 'false');
+        controlledElement.setAttribute('hidden', '');
+        headingElement.appendChild(toggleElement);
+        rootElement.appendChild(headingElement);
+        rootElement.appendChild(controlledElement);
+        return rootElement;
+    };
+    it('toggles the aria-expanded attribute on the toggle element.', () => {
+        const element: Element = createToggleWithControlled();
+        const toggle: HTMLElement | null = element.querySelector('button');
+        const controlled: HTMLElement | null = element.querySelector('div');
+        expect(toggle).not.toBeNull();
+        expect(controlled).not.toBeNull();
+        toggleExpandedHiddenState(toggle as HTMLElement, controlled as HTMLElement);
+        toggle?.click?.();
+        expect(toggle?.getAttribute?.('aria-expanded')).toEqual('true');
+        toggle?.click?.();
+        expect(toggle?.getAttribute?.('aria-expanded')).toEqual('false');
+    });
+    it('toggles the hidden attribute on the controlled element.', () => {
+        const element: Element = createToggleWithControlled();
+        const toggle: HTMLElement | null = element.querySelector('button');
+        const controlled: Element | null = element.querySelector('div');
+        expect(toggle).not.toBeNull();
+        expect(controlled).not.toBeNull();
+        toggleExpandedHiddenState(toggle as HTMLElement, controlled as HTMLElement);
+        toggle?.click?.();
+        expect(controlled?.hasAttribute?.('hidden')).toBeFalsy();
+        toggle?.click?.();
+        expect(controlled?.hasAttribute?.('hidden')).toBeTruthy();
+    });
+});
+
+describe('determineLandmarkRole function', () => {
+    const createNamedElement: (tagName: string) => Element = (tagName: string) => {
+        const element: Element = document.createElement(tagName);
+        return element;
+    };
+    const wrapElement: (wrapper: Element, wrapped: Element) => Element = (wrapper: Element, wrapped: Element) => {
+        wrapper.appendChild(wrapped);
+        return wrapper;
+    };
+    it('returns complementary for ASIDE elements.', () => {
+        const asideElement: Element = createNamedElement('aside');
+        const role: string = determineLandmarkRole(asideElement);
+        const complementaryRole: string = 'complementary';
+        expect(role).toEqual(complementaryRole);
+    });
+    it('returns contentinfo for FOOTER elements that are in a body context.', () => {
+        const footerElement: Element = createNamedElement('footer');
+        const bodyElement: Element = createNamedElement('body');
+        wrapElement(bodyElement, footerElement);
+        const role: string = determineLandmarkRole(footerElement);
+        const contentInfoRole: string = 'contentinfo';
+        expect(role).toEqual(contentInfoRole);
+    });
+    it('returns empty for FOOTER elements that are NOT in a body context.', () => {
+        const footerElement: Element = createNamedElement('footer');
+        const role: string = determineLandmarkRole(footerElement);
+        expect(role).toEqual('');
+    });
+    it('returns banner for HEADER elements that are in a body context.', () => {
+        const headerElement: Element = createNamedElement('header');
+        const bodyElement: Element = wrapElement(createNamedElement('body'), headerElement);
+        const role: string = determineLandmarkRole(headerElement);
+        const bannerRole: string = 'banner';
+        expect(role).toEqual(bannerRole);
+    });
+    it('returns empty for HEADER elements that are NOT in a body context.', () => {
+        const headerElement: Element = createNamedElement('header');
+        const role: string = determineLandmarkRole(headerElement);
+        expect(role).toEqual('');
+    });
+    it('returns main for MAIN elements.', () => {
+        const mainElement: Element = createNamedElement('main');
+        const role: string = determineLandmarkRole(mainElement);
+        const mainRole: string = 'main';
+        expect(role).toEqual(mainRole);
+    });
+    it('returns navigation for NAV elements.', () => {
+        const navElement: Element = createNamedElement('nav');
+        const role: string = determineLandmarkRole(navElement);
+        const navigationRole: string = 'navigation';
+        expect(role).toEqual(navigationRole);
+    });
+    it('returns region for SECTION elements that have aria-label attributes.', () => {
+        const sectionElement: Element = createNamedElement('section');
+        const labelText: string = 'label text';
+        sectionElement.setAttribute('aria-label', labelText);
+        const role: string = determineLandmarkRole(sectionElement);
+        const regionRole: string = 'region';
+        expect(role).toEqual(regionRole);
+    });
+    it('returns region for SECTION elements that have aria-labelledby attributes.', () => {
+        const sectionElement: Element = createNamedElement('section');
+        const labelId: string = 'label-id';
+        sectionElement.setAttribute('aria-labelledby', labelId);
+        const role: string = determineLandmarkRole(sectionElement);
+        const regionRole: string = 'region';
+        expect(role).toEqual(regionRole);
+    });
+    it('returns empty for SECTION elements that do not have both aria-label and aria-labelledby attributes.', () => {
+        const sectionElement: Element = createNamedElement('section');
+        const role: string = determineLandmarkRole(sectionElement);
+        expect(role).toEqual('');
+    });
+    it('returns empty for non-landmark elements.', () => {
+        const divElement: Element = createNamedElement('div');
+        const role: string = determineLandmarkRole(divElement);
+        expect(role).toEqual('');
+    });
+});
+
+describe('isButtonElement function', () => {
+    it('returns true for BUTTON elements.', () => {
+        const buttonElement: Element = document.createElement('button');
+        const isButton: boolean = isButtonElement(buttonElement);
+        expect(isButton).toEqual(true);
+    });
+    it('returns false for non BUTTON elements.', () => {
+        const divElement: Element = document.createElement('div');
+        const isButton: boolean = isButtonElement(divElement);
+        expect(isButton).toBeFalsy();
+    });
+});
+
+describe('selectElementOrDefault function', () => {
+    const createElement = () => {
+        const wrapped: Element = document.createElement('h3');
+        const wrapper: Element = document.createElement('div');
+        wrapper.appendChild(wrapped);
+        return wrapper;
+    }
+    it('returns the root element with an empty selector string.', () => {
+        const element: Element = createElement();
+        const selector: string = '';
+        const selected: Element | null = selectElementOrDefault(element, selector);
+        expect(selected).toBe(element);
+    });
+    it('returns the selected element.', () => {
+        const element: Element = createElement();
+        const selector: string = ':scope > h3';
+        const headingElement: Element | null = element.querySelector(selector);
+        const selected: Element | null = selectElementOrDefault(element, selector);
+        expect(selected).toBe(headingElement);
+    });
+    it('returns null for a selector string that does not identify an element.', () => {
+        const element: Element = createElement();
+        const selector: string = 'main';
+        const selected: Element | null = selectElementOrDefault(element, selector, null);
+        expect(selected).toBeNull();
+    });
+});
+
+describe('windowLocationIncludesUrl function', () => {
+    const originalWindowLocation: Location = window.location;
+    const mockLocationHref: string = 'https://foobar.com/url/path/file.html';
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: new URL(mockLocationHref),
+        });
+    });
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: originalWindowLocation,
+        });
+    });
+    it('returns true when the linkUrl identifies the current page.', () => {
+        const linkUrl: string = mockLocationHref;
+        const locationIncludesUrl: boolean = windowLocationIncludesUrl(linkUrl);
+        expect(locationIncludesUrl).toBeTruthy();
+    });
+    it('returns false when the linkUrl does not identify the current page.', () => {
+        const linkUrl: string = 'https://nothere.com/';
+        const locationIncludesUrl: boolean = windowLocationIncludesUrl(linkUrl);
+        expect(locationIncludesUrl).toBeFalsy();
+    });
+});
+
+describe('applyDescribedBy function', () => {
+    const createElement = (id: string = '') => {
+        const rootElement: Element = document.createElement('div');
+        const labelElement: Element = document.createElement('div');
+        if (id) {
+            labelElement.setAttribute('id', id);
+        }
+        rootElement.appendChild(labelElement);
+        return rootElement;
+    };
+
+    it('applies the id of the description element to the aria-describedby attribute.', () => {
+        const labelId: string = 'label-id';
+        const element: Element = createElement(labelId);
+        const selectorString: string = ':scope > div';
+        const viewModel: AccessibleElementDescriptionViewModel = new AccessibleElementDescriptionViewModel(selectorString);
+        const describedById: string | null = AccessibleElementDescriptionViewModel.applyDescribedBy(
+            element,
+            viewModel,
+        ).getAttribute('aria-describedby');
+        expect(describedById).toEqual(labelId);
+    });
+    it('applies a newly created ID to the description element to the aria-describedby attribute.', () => {
+        const element: Element = createElement();
+        const selectorString: string = ':scope > div';
+        const viewModel: AccessibleElementDescriptionViewModel = new AccessibleElementDescriptionViewModel(selectorString);
+        const describedById: string | null = AccessibleElementDescriptionViewModel.applyDescribedBy(
+            element,
+            viewModel,
+        ).getAttribute('aria-describedby');
+        expect(describedById).not.toEqual('');
+    });
+    it('returns the element unaffected if an empty selector is provided.', () => {
+        const element: Element = createElement();
+        const selectorString: string = '';
+        const viewModel: AccessibleElementDescriptionViewModel = new AccessibleElementDescriptionViewModel(selectorString);
+        const describedById: string | null = AccessibleElementDescriptionViewModel.applyDescribedBy(
+            element,
+            viewModel,
+        ).getAttribute('aria-describedby');
+        expect(describedById).toBeNull();
+    });
+});
+
+describe('The interceptClick function', () => {
+    it('returns a promise resolved when a button is clicked once.', async () => {
+        const buttonElement: HTMLElement = document.createElement('button');
+        const mockHandler: jest.Mock = jest.fn();
+        const promise: Promise<void> = interceptClick(buttonElement).then(mockHandler);
+        buttonElement.dispatchEvent(new MouseEvent('click'));
+        await promise;
+        expect(mockHandler).toHaveBeenCalled();
+        buttonElement.dispatchEvent(new MouseEvent('click'));
+        await promise;
+        expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('The queryChildren function', () => {
+    it('returns an array of elements that are found.', () => {
+        const baseElement: Element = document.createElement('div');
+        const buttonElements: Element[] = ['First', 'Middle', 'Last'].map((text: string) => {
+            const buttonElement: Element = document.createElement('button');
+            buttonElement.textContent = text;
+            return buttonElement;
+        });
+        baseElement.append(...buttonElements);
+        const selectors: string[] = [
+            ':scope > button:nth-of-type(1)',
+            ':scope > button:nth-of-type(2)',
+            ':scope > button:nth-of-type(3)',
+        ];
+        const selectedElements: (Element | null)[] = queryChildren(baseElement, selectors);
+        expect(selectedElements.length).toEqual(buttonElements.length);
+        expect(buttonElements.every((button: Element) => selectedElements.includes(button))).toEqual(true);
+        expect(selectedElements.every((selected: Element | null) => selected !== null)).toEqual(true);
+    });
+    it('returns an array of nulls for selecting elements that are not present.', () => {
+        const baseElement: Element = document.createElement('div');
+        const buttonElements: Element[] = ['First', 'Middle', 'Last'].map((text: string) => {
+            const buttonElement: Element = document.createElement('button');
+            buttonElement.textContent = text;
+            return buttonElement;
+        });
+        baseElement.append(...buttonElements);
+        const selectors: string[] = [
+            ':scope > a:nth-of-type(1)',
+            ':scope > p:nth-of-type(2)',
+            ':scope > section:nth-of-type(3)',
+        ];
+        const selectedElements: (Element | null)[] = queryChildren(baseElement, selectors);
+        expect(selectedElements.length).toEqual(selectors.length);
+        expect(selectedElements.every((element: Element | null) => element === null)).toEqual(true);
+    });
+});

--- a/utils/dom.test.ts
+++ b/utils/dom.test.ts
@@ -262,12 +262,6 @@ describe('selectElementOrDefault function', () => {
         const selected: Element | null = selectElementOrDefault(element, selector);
         expect(selected).toBe(headingElement);
     });
-    it('returns null for a selector string that does not identify an element.', () => {
-        const element: Element = createElement();
-        const selector: string = 'main';
-        const selected: Element | null = selectElementOrDefault(element, selector, null);
-        expect(selected).toBeNull();
-    });
 });
 
 describe('windowLocationIncludesUrl function', () => {

--- a/utils/dom.ts
+++ b/utils/dom.ts
@@ -1,10 +1,16 @@
 import { AnyKindOfFunction } from "../base/types";
 
-export function createElementID(prefix: string = '', suffix: string = ''): string {
+export function createElementID(
+    prefix: string = '',
+    suffix: string = '',
+): string {
     return [prefix, window.crypto.randomUUID(), suffix].join('');
 }
 
-export function ensureElementHasID(element: Element, idGenerator: (...args: string[]) => string = createElementID): string {
+export function ensureElementHasID(
+    element: Element,
+    idGenerator: (...args: string[]) => string = createElementID,
+): string {
     const elementID: string | null = element.getAttribute('id');
     if (!elementID) {
         const createdID: string = idGenerator();
@@ -14,7 +20,9 @@ export function ensureElementHasID(element: Element, idGenerator: (...args: stri
     return elementID;
 }
 
-export function targetElementIsToggleButton(eventTarget: EventTarget | null): boolean {
+export function targetElementIsToggleButton(
+    eventTarget: EventTarget | null,
+): boolean {
     const element: HTMLElement = eventTarget as HTMLElement;
     const isButton: boolean = element.getAttribute('role') === 'button';
     const isControl: boolean = element.hasAttribute('aria-controls');
@@ -22,7 +30,10 @@ export function targetElementIsToggleButton(eventTarget: EventTarget | null): bo
     return isButton && isControl && isExpandButton;
 }
 
-export function toggleExpandedHiddenState(toggleElement: HTMLElement, controlledElement: Element): void {
+export function toggleExpandedHiddenState(
+    toggleElement: HTMLElement,
+    controlledElement: Element,
+): void {
     toggleElement.addEventListener('click', () => {
         const expanded: string | null = toggleElement.getAttribute('aria-expanded');
         if (!expanded || expanded === 'false') {
@@ -81,14 +92,22 @@ export function isButtonElement(element: Element): boolean {
     return false;
 }
 
+/**
+ * Queries for a DOM Element instance using a provided selector string on a root element.
+ * A default element is returned if none is selected which defaults to the root element.
+ * @param rootElement Root DOM element from which to invoke querySelector.
+ * @param selector DOM query selector string.
+ * @param defaultElement Default DOM element to return if the selector returns null; defaults to rootElement.
+ * @returns The selected DOM element or the default.
+ */
 export function selectElementOrDefault(
     rootElement: Element,
     selector: string,
-    defaultElement: Element | null = rootElement,
-): Element | null {
+    defaultElement: Element = rootElement,
+): Element {
     if (selector !== '') {
         const selectedElement: Element | null = rootElement.querySelector(selector);
-        if (selectedElement) {
+        if (selectedElement !== null) {
             return selectedElement;
         }
     }
@@ -111,7 +130,10 @@ export function interceptClick(element: HTMLElement): Promise<void> {
     });
 }
 
-export function queryChildren(parentElement: Element, selectors: string[]): (Element | null)[] {
+export function queryChildren(
+    parentElement: Element,
+    selectors: string[],
+): (Element | null)[] {
     const elements: (Element | null)[] = selectors.map((selector: string) => {
         const element: Element | null = parentElement.querySelector(selector);
         return element;

--- a/utils/dom.ts
+++ b/utils/dom.ts
@@ -1,0 +1,120 @@
+import { AnyKindOfFunction } from "../base/types";
+
+export function createElementID(prefix: string = '', suffix: string = ''): string {
+    return [prefix, window.crypto.randomUUID(), suffix].join('');
+}
+
+export function ensureElementHasID(element: Element, idGenerator: (...args: string[]) => string = createElementID): string {
+    const elementID: string | null = element.getAttribute('id');
+    if (!elementID) {
+        const createdID: string = idGenerator();
+        element.setAttribute('id', createdID);
+        return createdID;
+    }
+    return elementID;
+}
+
+export function targetElementIsToggleButton(eventTarget: EventTarget | null): boolean {
+    const element: HTMLElement = eventTarget as HTMLElement;
+    const isButton: boolean = element.getAttribute('role') === 'button';
+    const isControl: boolean = element.hasAttribute('aria-controls');
+    const isExpandButton: boolean = element.hasAttribute('aria-expanded');
+    return isButton && isControl && isExpandButton;
+}
+
+export function toggleExpandedHiddenState(toggleElement: HTMLElement, controlledElement: Element): void {
+    toggleElement.addEventListener('click', () => {
+        const expanded: string | null = toggleElement.getAttribute('aria-expanded');
+        if (!expanded || expanded === 'false') {
+            toggleElement.setAttribute('aria-expanded', 'true');
+            controlledElement.removeAttribute('hidden');
+        } else {
+            toggleElement.setAttribute('aria-expanded', 'false');
+            controlledElement.setAttribute('hidden', '');
+        }
+    });
+}
+
+export function determineLandmarkRole(element: Element): string {
+    const isInBodyContext = () => {
+        const bodyElement: Element | null = element.closest('body');
+        return bodyElement !== null;
+    };
+    const roleMap: Record<string, () => string> = {
+        ASIDE: () => 'complementary',
+        FOOTER: () => {
+            if (isInBodyContext()) {
+                return 'contentinfo';
+            }
+            return '';
+        },
+        HEADER: () => {
+            if (isInBodyContext()) {
+                return 'banner';
+            }
+            return '';
+        },
+        MAIN: () => 'main',
+        NAV: () => 'navigation',
+        SECTION: () => {
+            const hasLabel: boolean = element.hasAttribute('aria-label');
+            const isLabelledBy: boolean = element.hasAttribute('aria-labelledby');
+            if (hasLabel || isLabelledBy) {
+                return 'region';
+            }
+            return '';
+        },
+    };
+    const { tagName } = element;
+    const isRuleDefined: boolean = roleMap.hasOwnProperty(tagName);
+    if (isRuleDefined) {
+        const role: string = roleMap[tagName]();
+        return role;
+    }
+    return '';
+}
+
+export function isButtonElement(element: Element): boolean {
+    if (element.tagName === 'BUTTON') {
+        return true;
+    }
+    return false;
+}
+
+export function selectElementOrDefault(
+    rootElement: Element,
+    selector: string,
+    defaultElement: Element | null = rootElement,
+): Element | null {
+    if (selector !== '') {
+        const selectedElement: Element | null = rootElement.querySelector(selector);
+        if (selectedElement) {
+            return selectedElement;
+        }
+    }
+    return defaultElement;
+}
+
+export function windowLocationIncludesUrl(linkUrl: string): boolean {
+    const isUrlCurrentPage: boolean = window.location.href.includes(linkUrl);
+    return isUrlCurrentPage;
+}
+
+export function interceptClick(element: HTMLElement): Promise<void> {
+    return new Promise((resolve: AnyKindOfFunction) => {
+        element.addEventListener('click', (e: MouseEvent) => {
+            resolve();
+        }, {
+            once: true,
+            passive: true,
+        });
+    });
+}
+
+export function queryChildren(parentElement: Element, selectors: string[]): (Element | null)[] {
+    const elements: (Element | null)[] = selectors.map((selector: string) => {
+        const element: Element | null = parentElement.querySelector(selector);
+        return element;
+    });
+    return elements;
+}

--- a/utils/keyboard-focus-trap.test.ts
+++ b/utils/keyboard-focus-trap.test.ts
@@ -1,5 +1,5 @@
 import { AnyKindOfFunction, KeyEventCallback } from '../utils';
-import { createTrappedElementKeyboardFocusHandler, DispatchFocusInvoker, FocusChange, FocusInvoker, MethodFocusInvoker, OpenCloseListener, trapElementKeyboardFocus, TrappedKeyboardFocusKeyPressInitializer, TrappedKeyboardFocusState } from './keyboard-focus-trap';
+import { ClickInvoker, createTrappedElementKeyboardFocusHandler, DispatchClickInvoker, DispatchFocusInvoker, FocusChange, FocusInvoker, MethodClickInvoker, MethodFocusInvoker, OpenCloseListener, trapElementKeyboardFocus, TrappedKeyboardFocusKeyPressInitializer, TrappedKeyboardFocusState } from './keyboard-focus-trap';
 
 describe('The TrappedKeyboardFocusState class', () => {
 
@@ -124,6 +124,28 @@ describe('The DispatchFocusInvoker class', () => {
         const invoker: FocusInvoker = new DispatchFocusInvoker();
         invoker.invokeFocus(element);
         expect(focusHandler).toHaveBeenCalled();
+    });
+});
+
+describe('MethodClickInvoker', () => {
+    it('invokes the click method on an element.', () => {
+        const element: HTMLElement = document.createElement('button');
+        element.textContent = 'Test Button';
+        const clickSpy = jest.spyOn(element, "click");
+        const invoker: ClickInvoker = new MethodClickInvoker();
+        invoker.invokeClick(element);
+        expect(clickSpy).toHaveBeenCalled();
+    });
+});
+
+describe('DispatchClickInvoker', () => {
+    it('dispatches a click event on an element.', () => {
+        const element: HTMLElement = document.createElement('button');
+        element.textContent = 'Test Button';
+        const dispatchEventSpy = jest.spyOn(element, 'dispatchEvent');
+        const invoker: ClickInvoker = new DispatchClickInvoker();
+        invoker.invokeClick(element);
+        expect(dispatchEventSpy).toHaveBeenCalled();
     });
 });
 

--- a/utils/keyboard-focus-trap.ts
+++ b/utils/keyboard-focus-trap.ts
@@ -33,6 +33,24 @@ export class DispatchFocusInvoker extends FocusInvoker {
     }
 }
 
+export abstract class ClickInvoker {
+    public abstract invokeClick(element: HTMLElement): void;
+}
+
+export class MethodClickInvoker extends ClickInvoker {
+    public invokeClick(element: HTMLElement): void {
+        element.click();
+    }
+}
+
+export class DispatchClickInvoker extends ClickInvoker {
+    public invokeClick(element: HTMLElement): void {
+        element.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+        }));
+    }
+}
+
 export class TrappedKeyboardFocusState {
 
     public constructor(


### PR DESCRIPTION
Refactors the project's structure after learning from initial iterations. The structure is changed into having subfolders for each component type with separate implementation/test pairing code files for types, ARIA, and interactivity. There are also a separation of concerns from 'utils.ts' into 'utils/{types, dom, collections,...}. Also some base types have been moved into a `base/types.ts`, and `base/events.ts`. 

Please notice how awesome is 100% code coverage :)